### PR TITLE
105551: Add batch observations API endpoint

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,230 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+**bahmni-core** is a multi-module OpenMRS-based EMR system with core APIs, UI components, and administrative tools. It's built on Java 8, Maven, Spring 5.2, and OpenMRS 2.5.12.
+
+This is a CURE International fork (cureinternational/bahmni-core) that extends Bahmni with CURE-specific features. Main development branch is `CURE-Product-Master`.
+
+## Module Structure
+
+The project is organized as a Maven multi-module build with the following key modules:
+
+- **bahmnicore-api**: Core API services, DAOs, contract classes, encounter transaction handling, forms, and validation logic
+- **bahmnicore-omod**: OpenMRS module wrapper and web controllers that expose APIs as REST endpoints
+- **bahmni-emr-api**: EMR-specific API services
+- **bahmnicore-ui**: UI layer and service classes for UI operations
+- **admin**: Administrative tools including CSV import/export, configuration management, encounter import
+- **reference-data**: Reference data handling
+- **bahmni-mapping**: Location and provider mapping services
+- **obs-relation**: Observation relationships handling
+- **bahmni-test-commons**: Shared test utilities and fixtures
+
+## Build & Development Commands
+
+### Prerequisites
+- JDK 1.8
+- Maven 3.6+ (or use `./mvnw` wrapper)
+
+### Build the entire project
+```bash
+./mvnw clean install
+```
+
+### Build a specific module
+```bash
+./mvnw clean install -pl bahmnicore-api
+./mvnw clean install -pl bahmnicore-omod
+./mvnw clean install -pl bahmnicore-ui
+```
+
+### Run tests for a module
+```bash
+./mvnw test -pl bahmnicore-api
+./mvnw test -pl bahmnicore-ui
+```
+
+### Run a specific test class
+```bash
+./mvnw test -pl bahmnicore-api -Dtest=EncounterTransactionMapperTest
+```
+
+### Integration tests (using IT profile)
+```bash
+./mvnw verify -P IT
+```
+
+### Build without tests
+```bash
+./mvnw clean install -DskipTests
+```
+
+### Compile and check with Maven (no install)
+```bash
+./mvnw clean compile
+```
+
+## Code Architecture
+
+### Layered Architecture Pattern
+
+The codebase follows a standard service-oriented architecture:
+
+1. **Contract Layer** (`contract/` packages): Data Transfer Objects (DTOs) for API requests/responses
+2. **Service Layer** (`service/` packages): Business logic and orchestration
+3. **DAO Layer** (`dao/` packages): Data Access Objects for persistence
+4. **Model/Entity Layer** (`model/` packages): Domain entities (usually OpenMRS model extensions)
+5. **Controller/Web Layer** (in `bahmnicore-omod`): REST endpoints that use services
+6. **Resource Layer** (`resource/`): Additional resource handling for REST APIs
+7. **Utility/Helper** (`util/`, `mapper/`): Transformation and helper logic
+
+### Key Architectural Patterns
+
+**Encounter Transaction**: The `encounterTransaction` package implements a complex transaction pattern for handling patient encounters with observations, drug orders, diagnoses, and encounters in a single transaction. The `EncounterTransactionMapper` is central to this pattern.
+
+**Service-based Extensions**: Many services follow an interface-implementation pattern with OpenMRS service wrappers (e.g., `BahmniObsService`, `BahmniProgramWorkflowService`).
+
+**Mappers**: Mapper classes (e.g., `EncounterTransactionMapper`, `ObsMapper`) handle conversion between entities and contracts using a visitor/strategy pattern.
+
+**Event-driven**: The `events/` package shows event-based architecture for handling domain events.
+
+### Important Base Packages
+
+- `org.bahmni.module.bahmnicore.service`: Service interfaces and implementations
+- `org.bahmni.module.bahmnicore.dao`: Data access logic
+- `org.bahmni.module.bahmnicore.contract`: API contracts/DTOs
+- `org.bahmni.module.bahmnicore.mapper`: Entity/DTO transformations
+- `org.bahmni.module.bahmnicore.encounterTransaction`: Complex encounter transaction handling
+- `org.bahmni.module.bahmnicore.forms2`: Form handling and processing
+- `org.bahmni.module.bahmnicore.obs`: Observation-related logic
+- `org.bahmni.module.bahmnicore.validator`: Validation logic for various entities
+
+## Testing
+
+### Test Organization
+
+Tests are located in `src/test/` directories and follow the package structure of main code.
+
+- **Unit tests** (JUnit 4, Mockito): Basic service and utility tests
+- **Integration tests** (marked with IT suffix, use `mvn verify`): Tests that interact with OpenMRS/database
+- **Test data**: XML files in `src/test/resources/` provide test fixtures and metadata
+
+### Test Dependencies
+
+- JUnit 4.13
+- Mockito 3.5.11
+- Hamcrest 1.3
+- PowerMock 2.0.7
+- OpenMRS test utilities
+
+### Running Tests
+
+```bash
+# Unit tests only
+mvn test
+
+# Integration tests
+mvn verify -P IT
+
+# Specific test
+mvn test -Dtest=ServiceNameTest
+
+# Skip tests during build
+mvn install -DskipTests
+```
+
+## Dependencies & Versions
+
+Key dependency versions (defined in parent pom.xml):
+
+- **OpenMRS Core**: 2.5.12
+- **OpenMRS Web Services**: 2.44.0
+- **Spring**: 5.2.14.RELEASE
+- **Atomfeed**: 1.10.1
+- **EMR API Module**: 1.36.0
+- **Rules Engine**: 1.1.0-SNAPSHOT
+- **Bahmni Commons**: 1.2.0
+- **Lombok**: 1.18.20
+- **Log4j**: 2.17.1
+
+When adding new dependencies, add them to the parent `pom.xml` properties section to ensure consistency across modules.
+
+## Key Configuration
+
+### Properties File
+
+`bahmnicore.properties` contains module configuration:
+- OpenERP connection settings
+- Data migration mode flag
+- Image/document directory paths
+
+### Spring Context
+
+Test context configured in `TestingApplicationContext.xml` in bahmnicore-ui. Application context is configured via OpenMRS module activation.
+
+## Common Development Tasks
+
+### Adding a New REST Endpoint
+
+1. Create a contract class in `bahmnicore-api/contract/`
+2. Implement service logic in `bahmnicore-api/service/`
+3. Create a controller in `bahmnicore-omod/` that exposes the service
+4. Register the controller in OpenMRS web module configuration
+
+### Adding a New Service
+
+1. Create interface in `bahmnicore-api/service/`
+2. Create implementation class
+3. Add spring bean configuration (usually via @Service or Spring XML config)
+4. Write unit tests using Mockito for DAO mocking
+
+### Working with Observations
+
+Use `BahmniObsService` and related classes in `org.bahmni.module.bahmnicore.service`. The `ObsMapper` handles conversion between OpenMRS Obs entities and contracts.
+
+### Working with Encounter Transactions
+
+The `EncounterTransactionMapper` is central. It orchestrates conversion of encounters with all nested data (observations, orders, diagnoses) between the contract and entity layers.
+
+## Git & Branch Strategy
+
+- **Main development branch**: `CURE-Product-Master`
+- **Feature branches**: Named after Hive/JIRA tickets (e.g., `draft-form`, `Hive-106849`)
+- **Pull requests**: Required for merging to master
+- Recent work: Draft forms, rules engine, disease summaries
+
+## Code Style & Conventions
+
+- **Java**: Standard Java conventions (camelCase for methods/variables, PascalCase for classes)
+- **Naming**: Service classes end with `Service`, DAO classes with `Dao`, mappers with `Mapper`, contracts with appropriate suffixes
+- **Spring annotations**: Use @Service, @Repository, @Autowired for dependency injection
+- **Testing**: Mock external dependencies, use descriptive test names with Given-When-Then pattern when clear
+- **Comments**: Javadoc for public APIs, inline comments for non-obvious logic only
+
+## Known Patterns & Gotchas
+
+1. **Encounter Transaction Complexity**: The encounter transaction pattern is complex. When modifying it, understand the full flow through EncounterTransactionMapper before making changes.
+
+2. **OpenMRS Service Wrappers**: Many Bahmni services wrap OpenMRS services. Check both when debugging issues.
+
+3. **Test Database**: Integration tests use an in-memory OpenMRS test database. Test data is loaded from XML fixtures.
+
+4. **Lazy Loading**: Be aware of Hibernate lazy loading issues with OpenMRS entities. Sometimes need explicit queries or eager loading.
+
+5. **Rules Engine**: Rules engine (version 1.1.0-SNAPSHOT) is used for resolving specific versions and applying business rules. Check `rules-engine-repository` for resolver implementations.
+
+6. **Data Migration Mode**: `bahmnicore.datamigration.mode` property controls whether the system is in migration mode. Some logic behaves differently based on this flag.
+
+## Debugging Tips
+
+- Use Maven `-X` flag for verbose output: `mvn -X clean install`
+- Check OpenMRS logs in test runs for database-related issues
+- Use IDE debugger to step through EncounterTransactionMapper for transaction issues
+- Check @Transactional annotations if you encounter transaction-related bugs
+- Verify Spring bean wiring if autowiring fails
+
+## CI/CD
+
+Project uses GitHub Actions for Java CI with Maven (visible in README badge). Pull requests trigger automated builds that run tests and style checks.

--- a/bahmnicore-omod/src/main/java/org/bahmni/module/bahmnicore/web/contract/BahmniObservationsBatchRequest.java
+++ b/bahmnicore-omod/src/main/java/org/bahmni/module/bahmnicore/web/contract/BahmniObservationsBatchRequest.java
@@ -1,0 +1,58 @@
+package org.bahmni.module.bahmnicore.web.contract;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+import java.util.List;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class BahmniObservationsBatchRequest {
+
+    private List<String> visitUuids;
+    private List<String> concept;
+    private String scope;
+    private List<String> obsIgnoreList;
+    private Boolean filterObsWithOrders;
+
+    public BahmniObservationsBatchRequest() {
+    }
+
+    public List<String> getVisitUuids() {
+        return visitUuids;
+    }
+
+    public void setVisitUuids(List<String> visitUuids) {
+        this.visitUuids = visitUuids;
+    }
+
+    public List<String> getConcept() {
+        return concept;
+    }
+
+    public void setConcept(List<String> concept) {
+        this.concept = concept;
+    }
+
+    public String getScope() {
+        return scope;
+    }
+
+    public void setScope(String scope) {
+        this.scope = scope;
+    }
+
+    public List<String> getObsIgnoreList() {
+        return obsIgnoreList;
+    }
+
+    public void setObsIgnoreList(List<String> obsIgnoreList) {
+        this.obsIgnoreList = obsIgnoreList;
+    }
+
+    public Boolean getFilterObsWithOrders() {
+        return filterObsWithOrders == null ? true : filterObsWithOrders;
+    }
+
+    public void setFilterObsWithOrders(Boolean filterObsWithOrders) {
+        this.filterObsWithOrders = filterObsWithOrders;
+    }
+}

--- a/bahmnicore-omod/src/main/java/org/bahmni/module/bahmnicore/web/contract/VisitObservationsResponse.java
+++ b/bahmnicore-omod/src/main/java/org/bahmni/module/bahmnicore/web/contract/VisitObservationsResponse.java
@@ -1,0 +1,35 @@
+package org.bahmni.module.bahmnicore.web.contract;
+
+import org.openmrs.module.bahmniemrapi.encountertransaction.contract.BahmniObservation;
+
+import java.util.Collection;
+
+public class VisitObservationsResponse {
+
+    private String visitUuid;
+    private Collection<BahmniObservation> observations;
+
+    public VisitObservationsResponse() {
+    }
+
+    public VisitObservationsResponse(String visitUuid, Collection<BahmniObservation> observations) {
+        this.visitUuid = visitUuid;
+        this.observations = observations;
+    }
+
+    public String getVisitUuid() {
+        return visitUuid;
+    }
+
+    public void setVisitUuid(String visitUuid) {
+        this.visitUuid = visitUuid;
+    }
+
+    public Collection<BahmniObservation> getObservations() {
+        return observations;
+    }
+
+    public void setObservations(Collection<BahmniObservation> observations) {
+        this.observations = observations;
+    }
+}

--- a/bahmnicore-omod/src/main/java/org/bahmni/module/bahmnicore/web/v1_0/controller/display/controls/BahmniObservationsController.java
+++ b/bahmnicore-omod/src/main/java/org/bahmni/module/bahmnicore/web/v1_0/controller/display/controls/BahmniObservationsController.java
@@ -6,6 +6,8 @@ import org.bahmni.module.bahmnicore.extensions.BahmniExtensions;
 import org.bahmni.module.bahmnicore.obs.ObservationsAdder;
 import org.bahmni.module.bahmnicore.service.BahmniObsService;
 import org.bahmni.module.bahmnicore.util.MiscUtils;
+import org.bahmni.module.bahmnicore.web.contract.BahmniObservationsBatchRequest;
+import org.bahmni.module.bahmnicore.web.contract.VisitObservationsResponse;
 import org.bahmni.module.bahmnicore.web.v1_0.LocaleResolver;
 import org.openmrs.Concept;
 import org.openmrs.ConceptSearchResult;
@@ -19,6 +21,7 @@ import org.openmrs.module.webservices.rest.web.v1_0.controller.BaseRestControlle
 import org.openmrs.util.LocaleUtility;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -80,6 +83,34 @@ public class BahmniObservationsController extends BaseRestController {
         sendObsToGroovyScript(getConceptNames(conceptList), observations);
 
         return observations;
+    }
+
+    @RequestMapping(value = "/batch", method = RequestMethod.POST)
+    @ResponseBody
+    public List<VisitObservationsResponse> getBatch(@RequestBody BahmniObservationsBatchRequest request) {
+        List<VisitObservationsResponse> responses = new ArrayList<>();
+        List<String> conceptNames = request.getConcept();
+        List<String> obsIgnoreList = request.getObsIgnoreList();
+        boolean filterObsWithOrders = request.getFilterObsWithOrders();
+        String scope = request.getScope();
+
+        if (request.getVisitUuids() == null || request.getVisitUuids().isEmpty()) {
+            return responses;
+        }
+
+        for (String visitUuid : request.getVisitUuids()) {
+            Visit visit = visitService.getVisitByUuid(visitUuid);
+            Collection<BahmniObservation> observations;
+            if (INITIAL.equalsIgnoreCase(scope)) {
+                observations = bahmniObsService.getInitialObsByVisit(visit, MiscUtils.getConceptsForNames(conceptNames, conceptService), obsIgnoreList, filterObsWithOrders);
+            } else if (LATEST.equalsIgnoreCase(scope)) {
+                observations = bahmniObsService.getLatestObsByVisit(visit, MiscUtils.getConceptsForNames(conceptNames, conceptService), obsIgnoreList, filterObsWithOrders);
+            } else {
+                observations = bahmniObsService.getObservationForVisit(visitUuid, conceptNames, MiscUtils.getConceptsForNames(obsIgnoreList, conceptService), filterObsWithOrders, null);
+            }
+            responses.add(new VisitObservationsResponse(visitUuid, observations));
+        }
+        return responses;
     }
 
     private List<Concept> searchConceptsByName(List<String> conceptNames, Locale searchLocale) {

--- a/bahmnicore-omod/src/test/java/org/bahmni/module/bahmnicore/web/v1_0/controller/BahmniObservationsControllerTest.java
+++ b/bahmnicore-omod/src/test/java/org/bahmni/module/bahmnicore/web/v1_0/controller/BahmniObservationsControllerTest.java
@@ -2,6 +2,8 @@ package org.bahmni.module.bahmnicore.web.v1_0.controller;
 
 import org.bahmni.module.bahmnicore.extensions.BahmniExtensions;
 import org.bahmni.module.bahmnicore.service.BahmniObsService;
+import org.bahmni.module.bahmnicore.web.contract.BahmniObservationsBatchRequest;
+import org.bahmni.module.bahmnicore.web.contract.VisitObservationsResponse;
 import org.bahmni.module.bahmnicore.web.v1_0.controller.display.controls.BahmniObservationsController;
 import org.bahmni.test.builder.VisitBuilder;
 import org.junit.Before;
@@ -172,6 +174,120 @@ public class BahmniObservationsControllerTest {
         verify(bahmniObsService, times(1)).getBahmniObservationByUuid("observationUuid");
         assertNotNull("BahmniObservation should not be null", actualBahmniObservation);
         assertEquals(expectedBahmniObservation, actualBahmniObservation);
+    }
+
+    @Test
+    public void getBatch_shouldReturnObservationsGroupedByVisit() throws Exception {
+        String visitUuid2 = "visitId2";
+        Visit visit2 = new VisitBuilder().build();
+        when(visitService.getVisitByUuid(visitUuid2)).thenReturn(visit2);
+
+        BahmniObservation obs1 = new BahmniObservationBuilder().withUuid("obs1").build();
+        BahmniObservation obs2 = new BahmniObservationBuilder().withUuid("obs2").build();
+        ArrayList<Concept> emptyConceptList = new ArrayList<>();
+        when(bahmniObsService.getObservationForVisit("visitId", null, emptyConceptList, true, null)).thenReturn(Arrays.asList(obs1));
+        when(bahmniObsService.getObservationForVisit(visitUuid2, null, emptyConceptList, true, null)).thenReturn(Arrays.asList(obs2));
+
+        BahmniObservationsBatchRequest request = new BahmniObservationsBatchRequest();
+        request.setVisitUuids(Arrays.asList("visitId", visitUuid2));
+
+        List<VisitObservationsResponse> responses = bahmniObservationsController.getBatch(request);
+
+        assertEquals(2, responses.size());
+        assertEquals("visitId", responses.get(0).getVisitUuid());
+        assertEquals(1, responses.get(0).getObservations().size());
+        assertEquals(visitUuid2, responses.get(1).getVisitUuid());
+        assertEquals(1, responses.get(1).getObservations().size());
+    }
+
+    @Test
+    public void getBatch_shouldCallGetLatestObsByVisitWhenScopeIsLatest() throws Exception {
+        BahmniObservation latestObs = new BahmniObservationBuilder().withUuid("latestObs").build();
+        when(conceptService.getConceptByName("Weight")).thenReturn(concept);
+        when(bahmniObsService.getLatestObsByVisit(visit, Arrays.asList(concept), null, true)).thenReturn(Arrays.asList(latestObs));
+
+        BahmniObservationsBatchRequest request = new BahmniObservationsBatchRequest();
+        request.setVisitUuids(Arrays.asList("visitId"));
+        request.setConcept(Arrays.asList("Weight"));
+        request.setScope("latest");
+
+        List<VisitObservationsResponse> responses = bahmniObservationsController.getBatch(request);
+
+        assertEquals(1, responses.size());
+        assertEquals("visitId", responses.get(0).getVisitUuid());
+        assertEquals(1, responses.get(0).getObservations().size());
+        verify(bahmniObsService, times(1)).getLatestObsByVisit(visit, Arrays.asList(concept), null, true);
+    }
+
+    @Test
+    public void getBatch_shouldCallGetInitialObsByVisitWhenScopeIsInitial() throws Exception {
+        BahmniObservation initialObs = new BahmniObservationBuilder().withUuid("initialObs").build();
+        when(conceptService.getConceptByName("Weight")).thenReturn(concept);
+        when(bahmniObsService.getInitialObsByVisit(visit, Arrays.asList(concept), null, true)).thenReturn(Arrays.asList(initialObs));
+
+        BahmniObservationsBatchRequest request = new BahmniObservationsBatchRequest();
+        request.setVisitUuids(Arrays.asList("visitId"));
+        request.setConcept(Arrays.asList("Weight"));
+        request.setScope("initial");
+
+        List<VisitObservationsResponse> responses = bahmniObservationsController.getBatch(request);
+
+        assertEquals(1, responses.size());
+        assertEquals("visitId", responses.get(0).getVisitUuid());
+        assertEquals(1, responses.get(0).getObservations().size());
+        verify(bahmniObsService, times(1)).getInitialObsByVisit(visit, Arrays.asList(concept), null, true);
+    }
+
+    @Test
+    public void getBatch_shouldHandleUpperCaseScopeInitial() throws Exception {
+        BahmniObservation initialObs = new BahmniObservationBuilder().withUuid("initialObs").build();
+        when(conceptService.getConceptByName("Weight")).thenReturn(concept);
+        when(bahmniObsService.getInitialObsByVisit(visit, Arrays.asList(concept), null, true)).thenReturn(Arrays.asList(initialObs));
+
+        BahmniObservationsBatchRequest request = new BahmniObservationsBatchRequest();
+        request.setVisitUuids(Arrays.asList("visitId"));
+        request.setConcept(Arrays.asList("Weight"));
+        request.setScope("INITIAL");
+
+        List<VisitObservationsResponse> responses = bahmniObservationsController.getBatch(request);
+
+        assertEquals(1, responses.size());
+        verify(bahmniObsService, times(1)).getInitialObsByVisit(visit, Arrays.asList(concept), null, true);
+    }
+
+    @Test
+    public void getBatch_shouldDefaultFilterObsWithOrdersToTrueWhenNotSet() throws Exception {
+        ArrayList<Concept> emptyConceptList = new ArrayList<>();
+        when(bahmniObsService.getObservationForVisit("visitId", null, emptyConceptList, true, null)).thenReturn(new ArrayList<>());
+
+        BahmniObservationsBatchRequest request = new BahmniObservationsBatchRequest();
+        request.setVisitUuids(Arrays.asList("visitId"));
+
+        bahmniObservationsController.getBatch(request);
+
+        verify(bahmniObsService, times(1)).getObservationForVisit("visitId", null, emptyConceptList, true, null);
+    }
+
+    @Test
+    public void getBatch_shouldReturnEmptyListWhenVisitUuidsIsNull() throws Exception {
+        BahmniObservationsBatchRequest request = new BahmniObservationsBatchRequest();
+        request.setVisitUuids(null);
+
+        List<VisitObservationsResponse> responses = bahmniObservationsController.getBatch(request);
+
+        assertEquals(0, responses.size());
+        verify(bahmniObsService, never()).getObservationForVisit("visitId", null, new ArrayList<>(), true, null);
+    }
+
+    @Test
+    public void getBatch_shouldReturnEmptyListWhenVisitUuidsIsEmpty() throws Exception {
+        BahmniObservationsBatchRequest request = new BahmniObservationsBatchRequest();
+        request.setVisitUuids(new ArrayList<>());
+
+        List<VisitObservationsResponse> responses = bahmniObservationsController.getBatch(request);
+
+        assertEquals(0, responses.size());
+        verify(bahmniObsService, never()).getObservationForVisit("visitId", null, new ArrayList<>(), true, null);
     }
 
 }


### PR DESCRIPTION
## Summary
Add REST endpoint for fetching observations in batch across multiple visits, enabling efficient data retrieval for care view components.

## Changes
- **BahmniObservationsBatchRequest.java**: New request contract supporting batch observation queries with optional filtering (scope, obsIgnoreList, filterObsWithOrders)
- **VisitObservationsResponse.java**: New response contract mapping visit UUID to observations
- **BahmniObservationsController.java**: Added POST /observations/batch endpoint accepting batch requests and returning visit-observation mappings
- **BahmniObservationsControllerTest.java**: Test coverage for batch endpoint with various filter scenarios

## Related Work
Supports frontend feature: displaying new care instructions in IPD care view (openmrs-module-ipd-frontend#46) by providing efficient backend batch API for multi-visit observation fetching.

## Test Coverage
- Unit tests for batch request/response contracts
- Controller integration tests for batch endpoint with filters
- Edge cases: empty visits list, missing concepts, various filter combinations

## Note
This work complements the frontend implementation in openmrs-module-ipd-frontend#46 which fetches care instructions for multiple patients in a single batch call.