### PR TITLE
HIVE-113267: Create order and link tasks for surgery related instructions

### DIFF
--- a/.github/workflows/build_publish.yml
+++ b/.github/workflows/build_publish.yml
@@ -41,6 +41,11 @@ jobs:
                 <username>${{ github.actor }}</username>
                 <password>${{ secrets.CURE_EMR_ORG_ACCESS_TOKEN }}</password>
               </server>
+              <server>
+                <id>github-operationtheater</id>
+                <username>${{ github.actor }}</username>
+                <password>${{ secrets.CURE_EMR_ORG_ACCESS_TOKEN }}</password>
+              </server>
             </servers>
           </settings>
           EOF

--- a/.github/workflows/validate_pr.yml
+++ b/.github/workflows/validate_pr.yml
@@ -20,6 +20,25 @@ jobs:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
+      - name: Configure Maven settings for GitHub Packages
+        run: |
+          mkdir -p ~/.m2
+          cat > ~/.m2/settings.xml <<EOF
+          <settings>
+            <servers>
+              <server>
+                <id>github</id>
+                <username>${{ github.actor }}</username>
+                <password>${{ secrets.CURE_EMR_ORG_ACCESS_TOKEN }}</password>
+              </server>
+              <server>
+                <id>github-operationtheater</id>
+                <username>${{ github.actor }}</username>
+                <password>${{ secrets.CURE_EMR_ORG_ACCESS_TOKEN }}</password>
+              </server>
+            </servers>
+          </settings>
+          EOF
       - name: Build with Maven
         run: |
           ./mvnw install -U -Dmaven.javadoc.skip=true -V -B -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn

--- a/bahmni-emr-api/pom.xml
+++ b/bahmni-emr-api/pom.xml
@@ -170,7 +170,7 @@
         <dependency>
             <groupId>org.openmrs.module</groupId>
             <artifactId>operationtheater-api</artifactId>
-            <version>1.9.0-SNAPSHOT</version>
+            <version>${operationtheater.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/bahmni-emr-api/pom.xml
+++ b/bahmni-emr-api/pom.xml
@@ -168,6 +168,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.openmrs.module</groupId>
+            <artifactId>operationtheater-api</artifactId>
+            <version>1.9.0-SNAPSHOT</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
         </dependency>

--- a/bahmni-emr-api/src/main/java/org/openmrs/module/bahmniemrapi/dao/SurgeryObsOrderLinkDao.java
+++ b/bahmni-emr-api/src/main/java/org/openmrs/module/bahmniemrapi/dao/SurgeryObsOrderLinkDao.java
@@ -1,0 +1,9 @@
+package org.openmrs.module.bahmniemrapi.dao;
+
+import org.openmrs.Encounter;
+import org.openmrs.Order;
+
+public interface SurgeryObsOrderLinkDao {
+
+    void assignOrderToUnlinkedObs(Order order, Encounter encounter);
+}

--- a/bahmni-emr-api/src/main/java/org/openmrs/module/bahmniemrapi/dao/impl/SurgeryObsOrderLinkDaoImpl.java
+++ b/bahmni-emr-api/src/main/java/org/openmrs/module/bahmniemrapi/dao/impl/SurgeryObsOrderLinkDaoImpl.java
@@ -1,0 +1,28 @@
+package org.openmrs.module.bahmniemrapi.dao.impl;
+
+import org.hibernate.SessionFactory;
+import org.openmrs.Encounter;
+import org.openmrs.Order;
+import org.openmrs.module.bahmniemrapi.dao.SurgeryObsOrderLinkDao;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public class SurgeryObsOrderLinkDaoImpl implements SurgeryObsOrderLinkDao {
+
+    private final SessionFactory sessionFactory;
+
+    @Autowired
+    public SurgeryObsOrderLinkDaoImpl(SessionFactory sessionFactory) {
+        this.sessionFactory = sessionFactory;
+    }
+
+    @Override
+    public void assignOrderToUnlinkedObs(Order order, Encounter encounter) {
+        sessionFactory.getCurrentSession()
+                .createQuery("UPDATE Obs o SET o.order = :order WHERE o.encounter = :encounter AND o.voided = false AND o.order IS NULL")
+                .setParameter("order", order)
+                .setParameter("encounter", encounter)
+                .executeUpdate();
+    }
+}

--- a/bahmni-emr-api/src/main/java/org/openmrs/module/bahmniemrapi/encountertransaction/command/impl/SurgeryOrderPostSaveCommandImpl.java
+++ b/bahmni-emr-api/src/main/java/org/openmrs/module/bahmniemrapi/encountertransaction/command/impl/SurgeryOrderPostSaveCommandImpl.java
@@ -9,6 +9,7 @@ import org.openmrs.EncounterProvider;
 import org.openmrs.Order;
 import org.openmrs.OrderType;
 import org.openmrs.Provider;
+import org.openmrs.api.AdministrationService;
 import org.openmrs.api.ConceptService;
 import org.openmrs.api.OrderService;
 import org.openmrs.api.context.Context;
@@ -18,25 +19,30 @@ import org.openmrs.module.emrapi.encounter.domain.EncounterTransaction;
 import org.openmrs.module.operationtheater.api.model.SurgicalAppointment;
 import org.openmrs.module.operationtheater.api.service.SurgicalAppointmentService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
 @Component
 public class SurgeryOrderPostSaveCommandImpl implements EncounterDataPostSaveCommand {
 
-    static final String SELECT_SURGERY_CONCEPT_NAME = "Select Surgery";
     static final String SURGERY_ORDER_TYPE_NAME = "Surgery Order";
     static final String GENERAL_ORDER_TYPE_NAME = "General Order";
+    static final String SURGERY_SELECTION_CONCEPT_GP = "bahmnicore.order.surgerySelectionConcept";
+    static final String SURGERY_SELECTION_CONCEPT_DEFAULT = "Select Surgery";
 
     private final OrderService orderService;
     private final ConceptService conceptService;
     private final SurgeryObsOrderLinkDao surgeryObsOrderLinkDao;
+    private final AdministrationService adminService;
 
     @Autowired
     public SurgeryOrderPostSaveCommandImpl(OrderService orderService, ConceptService conceptService,
-            SurgeryObsOrderLinkDao surgeryObsOrderLinkDao) {
+            SurgeryObsOrderLinkDao surgeryObsOrderLinkDao,
+            @Qualifier("adminService") AdministrationService adminService) {
         this.orderService = orderService;
         this.conceptService = conceptService;
         this.surgeryObsOrderLinkDao = surgeryObsOrderLinkDao;
+        this.adminService = adminService;
     }
 
     @Override
@@ -65,12 +71,17 @@ public class SurgeryOrderPostSaveCommandImpl implements EncounterDataPostSaveCom
         return updatedEncounterTransaction;
     }
 
+    private String surgerySelectionConceptName() {
+        return adminService.getGlobalProperty(SURGERY_SELECTION_CONCEPT_GP, SURGERY_SELECTION_CONCEPT_DEFAULT);
+    }
+
     private String findSurgicalAppointmentUuidFromNewObs(Encounter encounter) {
+        String conceptName = surgerySelectionConceptName();
         for (org.openmrs.Obs obs : encounter.getObs()) {
             if (!obs.getVoided() && obs.getOrder() == null
                     && obs.getConcept() != null
                     && obs.getConcept().getName() != null
-                    && SELECT_SURGERY_CONCEPT_NAME.equals(obs.getConcept().getName().getName())
+                    && conceptName.equals(obs.getConcept().getName().getName())
                     && StringUtils.isNotBlank(obs.getValueComplex())) {
                 return obs.getValueComplex();
             }
@@ -108,13 +119,11 @@ public class SurgeryOrderPostSaveCommandImpl implements EncounterDataPostSaveCom
             return null;
         }
 
-        // Fix 1: null guard on concept
-        Concept concept = conceptService.getConceptByName(SELECT_SURGERY_CONCEPT_NAME);
+        Concept concept = conceptService.getConceptByName(surgerySelectionConceptName());
         if (concept == null) {
             return null;
         }
 
-        // Fix 3: null guard on careSetting + use enum constant
         CareSetting careSetting = orderService.getCareSettingByName(
                 CareSetting.CareSettingType.OUTPATIENT.toString());
         if (careSetting == null) {

--- a/bahmni-emr-api/src/main/java/org/openmrs/module/bahmniemrapi/encountertransaction/command/impl/SurgeryOrderPostSaveCommandImpl.java
+++ b/bahmni-emr-api/src/main/java/org/openmrs/module/bahmniemrapi/encountertransaction/command/impl/SurgeryOrderPostSaveCommandImpl.java
@@ -13,14 +13,11 @@ import org.openmrs.api.ProviderService;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.bahmniemrapi.encountertransaction.command.EncounterDataPostSaveCommand;
 import org.openmrs.module.bahmniemrapi.encountertransaction.contract.BahmniEncounterTransaction;
-import org.openmrs.module.bahmniemrapi.encountertransaction.contract.BahmniObservation;
 import org.openmrs.module.emrapi.encounter.domain.EncounterTransaction;
 import org.openmrs.module.operationtheater.api.model.SurgicalAppointment;
 import org.openmrs.module.operationtheater.api.service.SurgicalAppointmentService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-
-import java.util.Collection;
 
 @Component
 public class SurgeryOrderPostSaveCommandImpl implements EncounterDataPostSaveCommand {
@@ -46,17 +43,18 @@ public class SurgeryOrderPostSaveCommandImpl implements EncounterDataPostSaveCom
     @Override
     public EncounterTransaction save(BahmniEncounterTransaction bahmniEncounterTransaction, Encounter currentEncounter,
             EncounterTransaction updatedEncounterTransaction) {
+        String surgicalApptUuid = findSurgicalAppointmentUuidFromNewObs(currentEncounter);
 
-        String surgicalApptUuid = findSurgicalAppointmentUuid(bahmniEncounterTransaction.getObservations());
-        String requiredOrderType = surgicalApptUuid != null ? SURGERY_ORDER_TYPE_NAME : GENERAL_ORDER_TYPE_NAME;
-
-        Order existingOrder = findOrderByType(currentEncounter, requiredOrderType);
+        Order existingOrder = surgicalApptUuid != null
+                ? findExistingOrderForSurgicalAppointment(surgicalApptUuid)
+                : findOrderByType(currentEncounter, GENERAL_ORDER_TYPE_NAME);
 
         if (existingOrder != null) {
             linkUnlinkedObsToOrder(existingOrder, currentEncounter);
             return updatedEncounterTransaction;
         }
 
+        String requiredOrderType = surgicalApptUuid != null ? SURGERY_ORDER_TYPE_NAME : GENERAL_ORDER_TYPE_NAME;
         Order newOrder = createOrder(requiredOrderType, currentEncounter);
         if (newOrder == null) {
             return updatedEncounterTransaction;
@@ -68,27 +66,26 @@ public class SurgeryOrderPostSaveCommandImpl implements EncounterDataPostSaveCom
         return updatedEncounterTransaction;
     }
 
-    private String findSurgicalAppointmentUuid(Collection<BahmniObservation> observations) {
-        if (observations == null) {
-            return null;
-        }
-        for (BahmniObservation obs : observations) {
-            if (isSelectSurgeryObs(obs)) {
-                return (String) obs.getValue();
-            }
-            String found = findSurgicalAppointmentUuid(obs.getGroupMembers());
-            if (found != null) {
-                return found;
+    private String findSurgicalAppointmentUuidFromNewObs(Encounter encounter) {
+        for (org.openmrs.Obs obs : encounter.getObs()) {
+            if (!obs.getVoided() && obs.getOrder() == null
+                    && obs.getConcept() != null
+                    && obs.getConcept().getName() != null
+                    && SELECT_SURGERY_CONCEPT_NAME.equals(obs.getConcept().getName().getName())
+                    && StringUtils.isNotBlank(obs.getValueComplex())) {
+                return obs.getValueComplex();
             }
         }
         return null;
     }
 
-    private boolean isSelectSurgeryObs(BahmniObservation obs) {
-        return obs.getConcept() != null
-                && SELECT_SURGERY_CONCEPT_NAME.equals(obs.getConcept().getName())
-                && obs.getValue() instanceof String
-                && StringUtils.isNotBlank((String) obs.getValue());
+    private Order findExistingOrderForSurgicalAppointment(String surgicalApptUuid) {
+        SurgicalAppointmentService svc = Context.getService(SurgicalAppointmentService.class);
+        SurgicalAppointment appt = svc.getSurgicalAppointmentByUuid(surgicalApptUuid);
+        if (appt != null && appt.getOrder() != null && !appt.getOrder().getVoided()) {
+            return appt.getOrder();
+        }
+        return null;
     }
 
     private Order findOrderByType(Encounter encounter, String orderTypeName) {
@@ -133,10 +130,9 @@ public class SurgeryOrderPostSaveCommandImpl implements EncounterDataPostSaveCom
         return null;
     }
 
-    // HQL bulk update bypasses ImmutableEntityInterceptor (same pattern as BahmniObsDaoImpl.updateObsMember).
     private void linkAllObsToOrder(Order order, Encounter encounter) {
         sessionFactory.getCurrentSession()
-                .createQuery("UPDATE Obs o SET o.order = :order WHERE o.encounter = :encounter AND o.voided = false")
+                .createQuery("UPDATE Obs o SET o.order = :order WHERE o.encounter = :encounter AND o.voided = false AND o.order IS NULL")
                 .setParameter("order", order)
                 .setParameter("encounter", encounter)
                 .executeUpdate();

--- a/bahmni-emr-api/src/main/java/org/openmrs/module/bahmniemrapi/encountertransaction/command/impl/SurgeryOrderPostSaveCommandImpl.java
+++ b/bahmni-emr-api/src/main/java/org/openmrs/module/bahmniemrapi/encountertransaction/command/impl/SurgeryOrderPostSaveCommandImpl.java
@@ -1,7 +1,9 @@
 package org.openmrs.module.bahmniemrapi.encountertransaction.command.impl;
 
 import org.apache.commons.lang3.StringUtils;
-import org.hibernate.SessionFactory;
+import org.openmrs.module.bahmniemrapi.dao.SurgeryObsOrderLinkDao;
+import org.openmrs.CareSetting;
+import org.openmrs.Concept;
 import org.openmrs.Encounter;
 import org.openmrs.EncounterProvider;
 import org.openmrs.Order;
@@ -9,7 +11,6 @@ import org.openmrs.OrderType;
 import org.openmrs.Provider;
 import org.openmrs.api.ConceptService;
 import org.openmrs.api.OrderService;
-import org.openmrs.api.ProviderService;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.bahmniemrapi.encountertransaction.command.EncounterDataPostSaveCommand;
 import org.openmrs.module.bahmniemrapi.encountertransaction.contract.BahmniEncounterTransaction;
@@ -28,16 +29,14 @@ public class SurgeryOrderPostSaveCommandImpl implements EncounterDataPostSaveCom
 
     private final OrderService orderService;
     private final ConceptService conceptService;
-    private final ProviderService providerService;
-    private final SessionFactory sessionFactory;
+    private final SurgeryObsOrderLinkDao surgeryObsOrderLinkDao;
 
     @Autowired
     public SurgeryOrderPostSaveCommandImpl(OrderService orderService, ConceptService conceptService,
-            ProviderService providerService, SessionFactory sessionFactory) {
+            SurgeryObsOrderLinkDao surgeryObsOrderLinkDao) {
         this.orderService = orderService;
         this.conceptService = conceptService;
-        this.providerService = providerService;
-        this.sessionFactory = sessionFactory;
+        this.surgeryObsOrderLinkDao = surgeryObsOrderLinkDao;
     }
 
     @Override
@@ -50,7 +49,7 @@ public class SurgeryOrderPostSaveCommandImpl implements EncounterDataPostSaveCom
                 : findOrderByType(currentEncounter, GENERAL_ORDER_TYPE_NAME);
 
         if (existingOrder != null) {
-            linkUnlinkedObsToOrder(existingOrder, currentEncounter);
+            surgeryObsOrderLinkDao.assignOrderToUnlinkedObs(existingOrder, currentEncounter);
             return updatedEncounterTransaction;
         }
 
@@ -60,7 +59,7 @@ public class SurgeryOrderPostSaveCommandImpl implements EncounterDataPostSaveCom
             return updatedEncounterTransaction;
         }
 
-        linkAllObsToOrder(newOrder, currentEncounter);
+        surgeryObsOrderLinkDao.assignOrderToUnlinkedObs(newOrder, currentEncounter);
         linkSurgicalAppointmentToOrder(surgicalApptUuid, newOrder);
 
         return updatedEncounterTransaction;
@@ -109,12 +108,25 @@ public class SurgeryOrderPostSaveCommandImpl implements EncounterDataPostSaveCom
             return null;
         }
 
+        // Fix 1: null guard on concept
+        Concept concept = conceptService.getConceptByName(SELECT_SURGERY_CONCEPT_NAME);
+        if (concept == null) {
+            return null;
+        }
+
+        // Fix 3: null guard on careSetting + use enum constant
+        CareSetting careSetting = orderService.getCareSettingByName(
+                CareSetting.CareSettingType.OUTPATIENT.toString());
+        if (careSetting == null) {
+            return null;
+        }
+
         Order order = new Order();
         order.setPatient(encounter.getPatient());
         order.setEncounter(encounter);
         order.setOrderType(orderType);
-        order.setConcept(conceptService.getConceptByName(SELECT_SURGERY_CONCEPT_NAME));
-        order.setCareSetting(orderService.getCareSettingByName("OUTPATIENT"));
+        order.setConcept(concept);
+        order.setCareSetting(careSetting);
         order.setOrderer(provider);
         order.setDateActivated(encounter.getEncounterDatetime());
 
@@ -128,22 +140,6 @@ public class SurgeryOrderPostSaveCommandImpl implements EncounterDataPostSaveCom
             }
         }
         return null;
-    }
-
-    private void linkAllObsToOrder(Order order, Encounter encounter) {
-        sessionFactory.getCurrentSession()
-                .createQuery("UPDATE Obs o SET o.order = :order WHERE o.encounter = :encounter AND o.voided = false AND o.order IS NULL")
-                .setParameter("order", order)
-                .setParameter("encounter", encounter)
-                .executeUpdate();
-    }
-
-    private void linkUnlinkedObsToOrder(Order order, Encounter encounter) {
-        sessionFactory.getCurrentSession()
-                .createQuery("UPDATE Obs o SET o.order = :order WHERE o.encounter = :encounter AND o.voided = false AND o.order IS NULL")
-                .setParameter("order", order)
-                .setParameter("encounter", encounter)
-                .executeUpdate();
     }
 
     private void linkSurgicalAppointmentToOrder(String surgicalApptUuid, Order order) {

--- a/bahmni-emr-api/src/main/java/org/openmrs/module/bahmniemrapi/encountertransaction/command/impl/SurgeryOrderPostSaveCommandImpl.java
+++ b/bahmni-emr-api/src/main/java/org/openmrs/module/bahmniemrapi/encountertransaction/command/impl/SurgeryOrderPostSaveCommandImpl.java
@@ -1,0 +1,164 @@
+package org.openmrs.module.bahmniemrapi.encountertransaction.command.impl;
+
+import org.apache.commons.lang3.StringUtils;
+import org.hibernate.SessionFactory;
+import org.openmrs.Encounter;
+import org.openmrs.EncounterProvider;
+import org.openmrs.Order;
+import org.openmrs.OrderType;
+import org.openmrs.Provider;
+import org.openmrs.api.ConceptService;
+import org.openmrs.api.OrderService;
+import org.openmrs.api.ProviderService;
+import org.openmrs.api.context.Context;
+import org.openmrs.module.bahmniemrapi.encountertransaction.command.EncounterDataPostSaveCommand;
+import org.openmrs.module.bahmniemrapi.encountertransaction.contract.BahmniEncounterTransaction;
+import org.openmrs.module.bahmniemrapi.encountertransaction.contract.BahmniObservation;
+import org.openmrs.module.emrapi.encounter.domain.EncounterTransaction;
+import org.openmrs.module.operationtheater.api.model.SurgicalAppointment;
+import org.openmrs.module.operationtheater.api.service.SurgicalAppointmentService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.Collection;
+
+@Component
+public class SurgeryOrderPostSaveCommandImpl implements EncounterDataPostSaveCommand {
+
+    static final String SELECT_SURGERY_CONCEPT_NAME = "Select Surgery";
+    static final String SURGERY_ORDER_TYPE_NAME = "Surgery Order";
+    static final String GENERAL_ORDER_TYPE_NAME = "General Order";
+
+    private final OrderService orderService;
+    private final ConceptService conceptService;
+    private final ProviderService providerService;
+    private final SessionFactory sessionFactory;
+
+    @Autowired
+    public SurgeryOrderPostSaveCommandImpl(OrderService orderService, ConceptService conceptService,
+            ProviderService providerService, SessionFactory sessionFactory) {
+        this.orderService = orderService;
+        this.conceptService = conceptService;
+        this.providerService = providerService;
+        this.sessionFactory = sessionFactory;
+    }
+
+    @Override
+    public EncounterTransaction save(BahmniEncounterTransaction bahmniEncounterTransaction, Encounter currentEncounter,
+            EncounterTransaction updatedEncounterTransaction) {
+
+        String surgicalApptUuid = findSurgicalAppointmentUuid(bahmniEncounterTransaction.getObservations());
+        String requiredOrderType = surgicalApptUuid != null ? SURGERY_ORDER_TYPE_NAME : GENERAL_ORDER_TYPE_NAME;
+
+        Order existingOrder = findOrderByType(currentEncounter, requiredOrderType);
+
+        if (existingOrder != null) {
+            linkUnlinkedObsToOrder(existingOrder, currentEncounter);
+            return updatedEncounterTransaction;
+        }
+
+        Order newOrder = createOrder(requiredOrderType, currentEncounter);
+        if (newOrder == null) {
+            return updatedEncounterTransaction;
+        }
+
+        linkAllObsToOrder(newOrder, currentEncounter);
+        linkSurgicalAppointmentToOrder(surgicalApptUuid, newOrder);
+
+        return updatedEncounterTransaction;
+    }
+
+    private String findSurgicalAppointmentUuid(Collection<BahmniObservation> observations) {
+        if (observations == null) {
+            return null;
+        }
+        for (BahmniObservation obs : observations) {
+            if (isSelectSurgeryObs(obs)) {
+                return (String) obs.getValue();
+            }
+            String found = findSurgicalAppointmentUuid(obs.getGroupMembers());
+            if (found != null) {
+                return found;
+            }
+        }
+        return null;
+    }
+
+    private boolean isSelectSurgeryObs(BahmniObservation obs) {
+        return obs.getConcept() != null
+                && SELECT_SURGERY_CONCEPT_NAME.equals(obs.getConcept().getName())
+                && obs.getValue() instanceof String
+                && StringUtils.isNotBlank((String) obs.getValue());
+    }
+
+    private Order findOrderByType(Encounter encounter, String orderTypeName) {
+        for (Order order : encounter.getOrders()) {
+            if (!order.getVoided() && order.getOrderType() != null
+                    && orderTypeName.equals(order.getOrderType().getName())) {
+                return order;
+            }
+        }
+        return null;
+    }
+
+    private Order createOrder(String orderTypeName, Encounter encounter) {
+        OrderType orderType = orderService.getOrderTypeByName(orderTypeName);
+        if (orderType == null) {
+            return null;
+        }
+
+        Provider provider = getPrimaryProvider(encounter);
+        if (provider == null) {
+            return null;
+        }
+
+        Order order = new Order();
+        order.setPatient(encounter.getPatient());
+        order.setEncounter(encounter);
+        order.setOrderType(orderType);
+        order.setConcept(conceptService.getConceptByName(SELECT_SURGERY_CONCEPT_NAME));
+        order.setCareSetting(orderService.getCareSettingByName("OUTPATIENT"));
+        order.setOrderer(provider);
+        order.setDateActivated(encounter.getEncounterDatetime());
+
+        return orderService.saveOrder(order, null);
+    }
+
+    private Provider getPrimaryProvider(Encounter encounter) {
+        for (EncounterProvider ep : encounter.getEncounterProviders()) {
+            if (ep.getProvider() != null) {
+                return ep.getProvider();
+            }
+        }
+        return null;
+    }
+
+    // HQL bulk update bypasses ImmutableEntityInterceptor (same pattern as BahmniObsDaoImpl.updateObsMember).
+    private void linkAllObsToOrder(Order order, Encounter encounter) {
+        sessionFactory.getCurrentSession()
+                .createQuery("UPDATE Obs o SET o.order = :order WHERE o.encounter = :encounter AND o.voided = false")
+                .setParameter("order", order)
+                .setParameter("encounter", encounter)
+                .executeUpdate();
+    }
+
+    private void linkUnlinkedObsToOrder(Order order, Encounter encounter) {
+        sessionFactory.getCurrentSession()
+                .createQuery("UPDATE Obs o SET o.order = :order WHERE o.encounter = :encounter AND o.voided = false AND o.order IS NULL")
+                .setParameter("order", order)
+                .setParameter("encounter", encounter)
+                .executeUpdate();
+    }
+
+    private void linkSurgicalAppointmentToOrder(String surgicalApptUuid, Order order) {
+        if (surgicalApptUuid == null) {
+            return;
+        }
+        SurgicalAppointmentService svc = Context.getService(SurgicalAppointmentService.class);
+        SurgicalAppointment appt = svc.getSurgicalAppointmentByUuid(surgicalApptUuid);
+        if (appt != null) {
+            appt.setOrder(order);
+            svc.save(appt);
+        }
+    }
+}

--- a/bahmni-emr-api/src/main/java/org/openmrs/module/bahmniemrapi/encountertransaction/command/impl/SurgeryOrderPostSaveCommandImpl.java
+++ b/bahmni-emr-api/src/main/java/org/openmrs/module/bahmniemrapi/encountertransaction/command/impl/SurgeryOrderPostSaveCommandImpl.java
@@ -28,7 +28,6 @@ public class SurgeryOrderPostSaveCommandImpl implements EncounterDataPostSaveCom
     static final String SURGERY_ORDER_TYPE_NAME = "Surgery Order";
     static final String GENERAL_ORDER_TYPE_NAME = "General Order";
     static final String SURGERY_SELECTION_CONCEPT_UUID_GP = "bahmnicore.order.surgerySelectionConceptUuid";
-    static final String SURGERY_SELECTION_CONCEPT_DEFAULT_NAME = "Select Surgery";
 
     private final OrderService orderService;
     private final ConceptService conceptService;
@@ -73,10 +72,10 @@ public class SurgeryOrderPostSaveCommandImpl implements EncounterDataPostSaveCom
 
     private Concept getSurgerySelectionConcept() {
         String conceptUuid = adminService.getGlobalProperty(SURGERY_SELECTION_CONCEPT_UUID_GP, "");
-        if (StringUtils.isNotBlank(conceptUuid)) {
-            return conceptService.getConceptByUuid(conceptUuid);
+        if (StringUtils.isBlank(conceptUuid)) {
+            return null;
         }
-        return conceptService.getConceptByName(SURGERY_SELECTION_CONCEPT_DEFAULT_NAME);
+        return conceptService.getConceptByUuid(conceptUuid);
     }
 
     private String findSurgicalAppointmentUuidFromNewObs(Encounter encounter) {

--- a/bahmni-emr-api/src/main/java/org/openmrs/module/bahmniemrapi/encountertransaction/command/impl/SurgeryOrderPostSaveCommandImpl.java
+++ b/bahmni-emr-api/src/main/java/org/openmrs/module/bahmniemrapi/encountertransaction/command/impl/SurgeryOrderPostSaveCommandImpl.java
@@ -27,8 +27,8 @@ public class SurgeryOrderPostSaveCommandImpl implements EncounterDataPostSaveCom
 
     static final String SURGERY_ORDER_TYPE_NAME = "Surgery Order";
     static final String GENERAL_ORDER_TYPE_NAME = "General Order";
-    static final String SURGERY_SELECTION_CONCEPT_GP = "bahmnicore.order.surgerySelectionConcept";
-    static final String SURGERY_SELECTION_CONCEPT_DEFAULT = "Select Surgery";
+    static final String SURGERY_SELECTION_CONCEPT_UUID_GP = "bahmnicore.order.surgerySelectionConceptUuid";
+    static final String SURGERY_SELECTION_CONCEPT_DEFAULT_NAME = "Select Surgery";
 
     private final OrderService orderService;
     private final ConceptService conceptService;
@@ -71,17 +71,23 @@ public class SurgeryOrderPostSaveCommandImpl implements EncounterDataPostSaveCom
         return updatedEncounterTransaction;
     }
 
-    private String surgerySelectionConceptName() {
-        return adminService.getGlobalProperty(SURGERY_SELECTION_CONCEPT_GP, SURGERY_SELECTION_CONCEPT_DEFAULT);
+    private Concept getSurgerySelectionConcept() {
+        String conceptUuid = adminService.getGlobalProperty(SURGERY_SELECTION_CONCEPT_UUID_GP, "");
+        if (StringUtils.isNotBlank(conceptUuid)) {
+            return conceptService.getConceptByUuid(conceptUuid);
+        }
+        return conceptService.getConceptByName(SURGERY_SELECTION_CONCEPT_DEFAULT_NAME);
     }
 
     private String findSurgicalAppointmentUuidFromNewObs(Encounter encounter) {
-        String conceptName = surgerySelectionConceptName();
+        Concept surgerySelectionConcept = getSurgerySelectionConcept();
+        if (surgerySelectionConcept == null) {
+            return null;
+        }
         for (org.openmrs.Obs obs : encounter.getObs()) {
             if (!obs.getVoided() && obs.getOrder() == null
                     && obs.getConcept() != null
-                    && obs.getConcept().getName() != null
-                    && conceptName.equals(obs.getConcept().getName().getName())
+                    && obs.getConcept().equals(surgerySelectionConcept)
                     && StringUtils.isNotBlank(obs.getValueComplex())) {
                 return obs.getValueComplex();
             }
@@ -119,7 +125,7 @@ public class SurgeryOrderPostSaveCommandImpl implements EncounterDataPostSaveCom
             return null;
         }
 
-        Concept concept = conceptService.getConceptByName(surgerySelectionConceptName());
+        Concept concept = getSurgerySelectionConcept();
         if (concept == null) {
             return null;
         }

--- a/bahmni-emr-api/src/test/java/org/openmrs/module/bahmniemrapi/encountertransaction/command/impl/SurgeryOrderPostSaveCommandImplTest.java
+++ b/bahmni-emr-api/src/test/java/org/openmrs/module/bahmniemrapi/encountertransaction/command/impl/SurgeryOrderPostSaveCommandImplTest.java
@@ -52,6 +52,7 @@ public class SurgeryOrderPostSaveCommandImplTest {
     @Mock private SurgicalAppointmentService surgicalAppointmentService;
 
     private SurgeryOrderPostSaveCommandImpl command;
+    private Concept selectSurgeryConcept;
 
     @Before
     public void setUp() {
@@ -59,10 +60,17 @@ public class SurgeryOrderPostSaveCommandImplTest {
         mockStatic(OpenmrsUtil.class);
         mockStatic(Context.class);
         command = new SurgeryOrderPostSaveCommandImpl(orderService, conceptService, surgeryObsOrderLinkDao, adminService);
+
+        // GP returns blank → falls back to name lookup
         when(adminService.getGlobalProperty(
-            SurgeryOrderPostSaveCommandImpl.SURGERY_SELECTION_CONCEPT_GP,
-            SurgeryOrderPostSaveCommandImpl.SURGERY_SELECTION_CONCEPT_DEFAULT))
-            .thenReturn("Select Surgery");
+            SurgeryOrderPostSaveCommandImpl.SURGERY_SELECTION_CONCEPT_UUID_GP, ""))
+            .thenReturn("");
+
+        // Shared concept instance — obs detection and order creation both use this
+        selectSurgeryConcept = PowerMockito.mock(Concept.class);
+        when(conceptService.getConceptByName(
+            SurgeryOrderPostSaveCommandImpl.SURGERY_SELECTION_CONCEPT_DEFAULT_NAME))
+            .thenReturn(selectSurgeryConcept);
     }
 
     @Test
@@ -74,7 +82,7 @@ public class SurgeryOrderPostSaveCommandImplTest {
         when(orderService.getOrderTypeByName("Surgery Order")).thenReturn(surgeryOrderType);
         when(orderService.saveOrder(any(Order.class), eq(null))).thenReturn(new Order());
         when(orderService.getCareSettingByName("OUTPATIENT")).thenReturn(new CareSetting());
-        when(conceptService.getConceptByName("Select Surgery")).thenReturn(new Concept());
+        
 
         SurgicalAppointment appt = new SurgicalAppointment();
         PowerMockito.when(Context.getService(SurgicalAppointmentService.class)).thenReturn(surgicalAppointmentService);
@@ -99,7 +107,7 @@ public class SurgeryOrderPostSaveCommandImplTest {
         when(orderService.getOrderTypeByName("General Order")).thenReturn(orderTypeWithName("General Order"));
         when(orderService.saveOrder(any(Order.class), eq(null))).thenReturn(new Order());
         when(orderService.getCareSettingByName("OUTPATIENT")).thenReturn(new CareSetting());
-        when(conceptService.getConceptByName("Select Surgery")).thenReturn(new Concept());
+        
 
         command.save(bet, encounterWithProvider(), new EncounterTransaction());
 
@@ -118,7 +126,7 @@ public class SurgeryOrderPostSaveCommandImplTest {
         when(orderService.getOrderTypeByName("General Order")).thenReturn(orderTypeWithName("General Order"));
         when(orderService.saveOrder(any(Order.class), eq(null))).thenReturn(new Order());
         when(orderService.getCareSettingByName("OUTPATIENT")).thenReturn(new CareSetting());
-        when(conceptService.getConceptByName("Select Surgery")).thenReturn(new Concept());
+        
 
         Encounter encounter = encounterWithProvider();
         // "Select Surgery" obs from Form 1 already has an order — should be ignored
@@ -170,7 +178,7 @@ public class SurgeryOrderPostSaveCommandImplTest {
         when(orderService.getOrderTypeByName("Surgery Order")).thenReturn(orderTypeWithName("Surgery Order"));
         when(orderService.saveOrder(any(Order.class), eq(null))).thenReturn(new Order());
         when(orderService.getCareSettingByName("OUTPATIENT")).thenReturn(new CareSetting());
-        when(conceptService.getConceptByName("Select Surgery")).thenReturn(new Concept());
+        
 
         Encounter encounter = encounterWithProvider();
         // Surgery A order already on encounter
@@ -212,7 +220,7 @@ public class SurgeryOrderPostSaveCommandImplTest {
         when(orderService.getOrderTypeByName("Surgery Order")).thenReturn(surgeryType);
         when(orderService.saveOrder(any(Order.class), eq(null))).thenReturn(new Order());
         when(orderService.getCareSettingByName("OUTPATIENT")).thenReturn(new CareSetting());
-        when(conceptService.getConceptByName("Select Surgery")).thenReturn(new Concept());
+        
 
         SurgicalAppointment appt = new SurgicalAppointment();
         PowerMockito.when(Context.getService(SurgicalAppointmentService.class)).thenReturn(surgicalAppointmentService);
@@ -244,7 +252,7 @@ public class SurgeryOrderPostSaveCommandImplTest {
         when(orderService.getOrderTypeByName("Surgery Order")).thenReturn(orderTypeWithName("Surgery Order"));
         when(orderService.saveOrder(any(Order.class), eq(null))).thenReturn(new Order());
         when(orderService.getCareSettingByName("OUTPATIENT")).thenReturn(new CareSetting());
-        when(conceptService.getConceptByName("Select Surgery")).thenReturn(new Concept());
+        
 
         PowerMockito.when(Context.getService(SurgicalAppointmentService.class)).thenReturn(surgicalAppointmentService);
         when(surgicalAppointmentService.getSurgicalAppointmentByUuid("nested-appt-uuid"))
@@ -266,7 +274,7 @@ public class SurgeryOrderPostSaveCommandImplTest {
         bet.setObservations(new ArrayList<>());
 
         when(orderService.getOrderTypeByName(anyString())).thenReturn(orderTypeWithName("General Order"));
-        when(conceptService.getConceptByName("Select Surgery")).thenReturn(new Concept());
+        
         when(orderService.getCareSettingByName(anyString())).thenReturn(new CareSetting());
 
         Encounter encounter = new Encounter();
@@ -288,7 +296,7 @@ public class SurgeryOrderPostSaveCommandImplTest {
         when(orderService.getOrderTypeByName("Surgery Order")).thenReturn(surgeryType);
         when(orderService.saveOrder(any(Order.class), eq(null))).thenReturn(new Order());
         when(orderService.getCareSettingByName(anyString())).thenReturn(new CareSetting());
-        when(conceptService.getConceptByName("Select Surgery")).thenReturn(new Concept());
+        
 
         PowerMockito.when(Context.getService(SurgicalAppointmentService.class)).thenReturn(surgicalAppointmentService);
         when(surgicalAppointmentService.getSurgicalAppointmentByUuid("appt-uuid-123")).thenReturn(null);
@@ -305,14 +313,8 @@ public class SurgeryOrderPostSaveCommandImplTest {
     // --- helpers ---
 
     private Obs selectSurgeryObs(String apptUuid) {
-        ConceptName conceptName = new ConceptName();
-        conceptName.setName("Select Surgery");
-
-        Concept concept = PowerMockito.mock(Concept.class);
-        when(concept.getName()).thenReturn(conceptName);
-
         Obs obs = new Obs();
-        obs.setConcept(concept);
+        obs.setConcept(selectSurgeryConcept);
         obs.setValueComplex(apptUuid);
         obs.setVoided(false);
         return obs;

--- a/bahmni-emr-api/src/test/java/org/openmrs/module/bahmniemrapi/encountertransaction/command/impl/SurgeryOrderPostSaveCommandImplTest.java
+++ b/bahmni-emr-api/src/test/java/org/openmrs/module/bahmniemrapi/encountertransaction/command/impl/SurgeryOrderPostSaveCommandImplTest.java
@@ -14,6 +14,7 @@ import org.openmrs.Obs;
 import org.openmrs.Order;
 import org.openmrs.OrderType;
 import org.openmrs.Provider;
+import org.openmrs.api.AdministrationService;
 import org.openmrs.api.ConceptService;
 import org.openmrs.api.OrderService;
 import org.openmrs.api.context.Context;
@@ -47,6 +48,7 @@ public class SurgeryOrderPostSaveCommandImplTest {
     @Mock private OrderService orderService;
     @Mock private ConceptService conceptService;
     @Mock private SurgeryObsOrderLinkDao surgeryObsOrderLinkDao;
+    @Mock private AdministrationService adminService;
     @Mock private SurgicalAppointmentService surgicalAppointmentService;
 
     private SurgeryOrderPostSaveCommandImpl command;
@@ -56,7 +58,11 @@ public class SurgeryOrderPostSaveCommandImplTest {
         initMocks(this);
         mockStatic(OpenmrsUtil.class);
         mockStatic(Context.class);
-        command = new SurgeryOrderPostSaveCommandImpl(orderService, conceptService, surgeryObsOrderLinkDao);
+        command = new SurgeryOrderPostSaveCommandImpl(orderService, conceptService, surgeryObsOrderLinkDao, adminService);
+        when(adminService.getGlobalProperty(
+            SurgeryOrderPostSaveCommandImpl.SURGERY_SELECTION_CONCEPT_GP,
+            SurgeryOrderPostSaveCommandImpl.SURGERY_SELECTION_CONCEPT_DEFAULT))
+            .thenReturn("Select Surgery");
     }
 
     @Test

--- a/bahmni-emr-api/src/test/java/org/openmrs/module/bahmniemrapi/encountertransaction/command/impl/SurgeryOrderPostSaveCommandImplTest.java
+++ b/bahmni-emr-api/src/test/java/org/openmrs/module/bahmniemrapi/encountertransaction/command/impl/SurgeryOrderPostSaveCommandImplTest.java
@@ -1,8 +1,6 @@
 package org.openmrs.module.bahmniemrapi.encountertransaction.command.impl;
 
-import org.hibernate.Session;
-import org.hibernate.SessionFactory;
-import org.hibernate.query.Query;
+import org.openmrs.module.bahmniemrapi.dao.SurgeryObsOrderLinkDao;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -18,7 +16,6 @@ import org.openmrs.OrderType;
 import org.openmrs.Provider;
 import org.openmrs.api.ConceptService;
 import org.openmrs.api.OrderService;
-import org.openmrs.api.ProviderService;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.bahmniemrapi.encountertransaction.contract.BahmniEncounterTransaction;
 import org.openmrs.module.emrapi.encounter.domain.EncounterTransaction;
@@ -49,10 +46,7 @@ public class SurgeryOrderPostSaveCommandImplTest {
 
     @Mock private OrderService orderService;
     @Mock private ConceptService conceptService;
-    @Mock private ProviderService providerService;
-    @Mock private SessionFactory sessionFactory;
-    @Mock private Session session;
-    @Mock private Query query;
+    @Mock private SurgeryObsOrderLinkDao surgeryObsOrderLinkDao;
     @Mock private SurgicalAppointmentService surgicalAppointmentService;
 
     private SurgeryOrderPostSaveCommandImpl command;
@@ -62,12 +56,7 @@ public class SurgeryOrderPostSaveCommandImplTest {
         initMocks(this);
         mockStatic(OpenmrsUtil.class);
         mockStatic(Context.class);
-        command = new SurgeryOrderPostSaveCommandImpl(orderService, conceptService, providerService, sessionFactory);
-
-        when(sessionFactory.getCurrentSession()).thenReturn(session);
-        when(session.createQuery(anyString())).thenReturn(query);
-        when(query.setParameter(anyString(), any())).thenReturn(query);
-        when(query.executeUpdate()).thenReturn(1);
+        command = new SurgeryOrderPostSaveCommandImpl(orderService, conceptService, surgeryObsOrderLinkDao);
     }
 
     @Test
@@ -92,7 +81,7 @@ public class SurgeryOrderPostSaveCommandImplTest {
 
         verify(orderService).getOrderTypeByName("Surgery Order");
         verify(orderService).saveOrder(any(Order.class), eq(null));
-        verify(query).executeUpdate();
+        verify(surgeryObsOrderLinkDao).assignOrderToUnlinkedObs(any(Order.class), any(Encounter.class));
         verify(surgicalAppointmentService).save(appt);
     }
 
@@ -156,7 +145,7 @@ public class SurgeryOrderPostSaveCommandImplTest {
         command.save(bet, encounter, new EncounterTransaction());
 
         verify(orderService, never()).saveOrder(any(Order.class), any());
-        verify(query).executeUpdate();
+        verify(surgeryObsOrderLinkDao).assignOrderToUnlinkedObs(any(Order.class), any(Encounter.class));
     }
 
     @Test
@@ -201,7 +190,7 @@ public class SurgeryOrderPostSaveCommandImplTest {
         command.save(bet, encounter, new EncounterTransaction());
 
         verify(orderService, never()).saveOrder(any(Order.class), any());
-        verify(query).executeUpdate();
+        verify(surgeryObsOrderLinkDao).assignOrderToUnlinkedObs(any(Order.class), any(Encounter.class));
     }
 
     @Test
@@ -238,7 +227,7 @@ public class SurgeryOrderPostSaveCommandImplTest {
         command.save(bet, encounterWithProvider(), new EncounterTransaction());
 
         verify(orderService, never()).saveOrder(any(Order.class), any());
-        verify(query, never()).executeUpdate();
+        verify(surgeryObsOrderLinkDao, never()).assignOrderToUnlinkedObs(any(Order.class), any(Encounter.class));
     }
 
     @Test
@@ -263,6 +252,48 @@ public class SurgeryOrderPostSaveCommandImplTest {
         verify(orderService).getOrderTypeByName("Surgery Order");
         // Called twice: once to check for existing order, once to link the appointment to the new order
         verify(surgicalAppointmentService, org.mockito.Mockito.times(2)).getSurgicalAppointmentByUuid("nested-appt-uuid");
+    }
+
+    @Test
+    public void shouldNotCreateOrderWhenNoProviderOnEncounter() {
+        BahmniEncounterTransaction bet = new BahmniEncounterTransaction();
+        bet.setObservations(new ArrayList<>());
+
+        when(orderService.getOrderTypeByName(anyString())).thenReturn(orderTypeWithName("General Order"));
+        when(conceptService.getConceptByName("Select Surgery")).thenReturn(new Concept());
+        when(orderService.getCareSettingByName(anyString())).thenReturn(new CareSetting());
+
+        Encounter encounter = new Encounter();
+        encounter.setOrders(new HashSet<>());
+        encounter.setEncounterProviders(Collections.emptySet());
+
+        command.save(bet, encounter, new EncounterTransaction());
+
+        verify(orderService, never()).saveOrder(any(Order.class), any());
+        verify(surgeryObsOrderLinkDao, never()).assignOrderToUnlinkedObs(any(Order.class), any(Encounter.class));
+    }
+
+    @Test
+    public void shouldNotSaveSurgicalAppointmentWhenNotFoundByUuid() {
+        BahmniEncounterTransaction bet = new BahmniEncounterTransaction();
+        bet.setObservations(new ArrayList<>());
+
+        OrderType surgeryType = orderTypeWithName("Surgery Order");
+        when(orderService.getOrderTypeByName("Surgery Order")).thenReturn(surgeryType);
+        when(orderService.saveOrder(any(Order.class), eq(null))).thenReturn(new Order());
+        when(orderService.getCareSettingByName(anyString())).thenReturn(new CareSetting());
+        when(conceptService.getConceptByName("Select Surgery")).thenReturn(new Concept());
+
+        PowerMockito.when(Context.getService(SurgicalAppointmentService.class)).thenReturn(surgicalAppointmentService);
+        when(surgicalAppointmentService.getSurgicalAppointmentByUuid("appt-uuid-123")).thenReturn(null);
+
+        Encounter encounter = encounterWithProvider();
+        encounter.addObs(selectSurgeryObs("appt-uuid-123"));
+
+        command.save(bet, encounter, new EncounterTransaction());
+
+        verify(orderService).saveOrder(any(Order.class), eq(null));
+        verify(surgicalAppointmentService, never()).save(any());
     }
 
     // --- helpers ---

--- a/bahmni-emr-api/src/test/java/org/openmrs/module/bahmniemrapi/encountertransaction/command/impl/SurgeryOrderPostSaveCommandImplTest.java
+++ b/bahmni-emr-api/src/test/java/org/openmrs/module/bahmniemrapi/encountertransaction/command/impl/SurgeryOrderPostSaveCommandImplTest.java
@@ -61,16 +61,15 @@ public class SurgeryOrderPostSaveCommandImplTest {
         mockStatic(Context.class);
         command = new SurgeryOrderPostSaveCommandImpl(orderService, conceptService, surgeryObsOrderLinkDao, adminService);
 
-        // GP returns blank → falls back to name lookup
+        // GP configured with a test UUID
+        String testConceptUuid = "test-concept-uuid-123";
         when(adminService.getGlobalProperty(
             SurgeryOrderPostSaveCommandImpl.SURGERY_SELECTION_CONCEPT_UUID_GP, ""))
-            .thenReturn("");
+            .thenReturn(testConceptUuid);
 
         // Shared concept instance — obs detection and order creation both use this
         selectSurgeryConcept = PowerMockito.mock(Concept.class);
-        when(conceptService.getConceptByName(
-            SurgeryOrderPostSaveCommandImpl.SURGERY_SELECTION_CONCEPT_DEFAULT_NAME))
-            .thenReturn(selectSurgeryConcept);
+        when(conceptService.getConceptByUuid(testConceptUuid)).thenReturn(selectSurgeryConcept);
     }
 
     @Test

--- a/bahmni-emr-api/src/test/java/org/openmrs/module/bahmniemrapi/encountertransaction/command/impl/SurgeryOrderPostSaveCommandImplTest.java
+++ b/bahmni-emr-api/src/test/java/org/openmrs/module/bahmniemrapi/encountertransaction/command/impl/SurgeryOrderPostSaveCommandImplTest.java
@@ -1,0 +1,247 @@
+package org.openmrs.module.bahmniemrapi.encountertransaction.command.impl;
+
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+import org.hibernate.query.Query;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.openmrs.CareSetting;
+import org.openmrs.Concept;
+import org.openmrs.Encounter;
+import org.openmrs.EncounterProvider;
+import org.openmrs.Order;
+import org.openmrs.OrderType;
+import org.openmrs.Provider;
+import org.openmrs.api.ConceptService;
+import org.openmrs.api.OrderService;
+import org.openmrs.api.ProviderService;
+import org.openmrs.api.context.Context;
+import org.openmrs.module.bahmniemrapi.encountertransaction.contract.BahmniEncounterTransaction;
+import org.openmrs.module.bahmniemrapi.encountertransaction.contract.BahmniObservation;
+import org.openmrs.module.emrapi.encounter.domain.EncounterTransaction;
+import org.openmrs.module.operationtheater.api.model.SurgicalAppointment;
+import org.openmrs.module.operationtheater.api.service.SurgicalAppointmentService;
+import org.openmrs.util.OpenmrsUtil;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
+
+@PrepareForTest({Context.class, OpenmrsUtil.class})
+@RunWith(PowerMockRunner.class)
+public class SurgeryOrderPostSaveCommandImplTest {
+
+    @Mock private OrderService orderService;
+    @Mock private ConceptService conceptService;
+    @Mock private ProviderService providerService;
+    @Mock private SessionFactory sessionFactory;
+    @Mock private Session session;
+    @Mock private Query query;
+    @Mock private SurgicalAppointmentService surgicalAppointmentService;
+
+    private SurgeryOrderPostSaveCommandImpl command;
+
+    @Before
+    public void setUp() {
+        initMocks(this);
+        mockStatic(OpenmrsUtil.class);
+        mockStatic(Context.class);
+        command = new SurgeryOrderPostSaveCommandImpl(orderService, conceptService, providerService, sessionFactory);
+
+        when(sessionFactory.getCurrentSession()).thenReturn(session);
+        when(session.createQuery(anyString())).thenReturn(query);
+        when(query.setParameter(anyString(), any())).thenReturn(query);
+        when(query.executeUpdate()).thenReturn(1);
+    }
+
+    @Test
+    public void shouldCreateSurgeryOrderWhenSelectSurgeryObsPresent() {
+        BahmniEncounterTransaction bet = new BahmniEncounterTransaction();
+        bet.setObservations(Collections.singletonList(buildSelectSurgeryObs("appt-uuid-123")));
+
+        OrderType surgeryOrderType = orderTypeWithName("Surgery Order");
+        when(orderService.getOrderTypeByName("Surgery Order")).thenReturn(surgeryOrderType);
+        when(orderService.saveOrder(any(Order.class), eq(null))).thenReturn(new Order());
+        when(orderService.getCareSettingByName("OUTPATIENT")).thenReturn(new CareSetting());
+        when(conceptService.getConceptByName("Select Surgery")).thenReturn(new Concept());
+
+        SurgicalAppointment appt = new SurgicalAppointment();
+        PowerMockito.when(Context.getService(SurgicalAppointmentService.class)).thenReturn(surgicalAppointmentService);
+        when(surgicalAppointmentService.getSurgicalAppointmentByUuid("appt-uuid-123")).thenReturn(appt);
+
+        command.save(bet, encounterWithProvider(), new EncounterTransaction());
+
+        verify(orderService).getOrderTypeByName("Surgery Order");
+        verify(orderService).saveOrder(any(Order.class), eq(null));
+        verify(query).executeUpdate();
+        verify(surgicalAppointmentService).save(appt);
+    }
+
+    @Test
+    public void shouldCreateGeneralOrderWhenNoSelectSurgeryObs() {
+        BahmniEncounterTransaction bet = new BahmniEncounterTransaction();
+        bet.setObservations(Collections.singletonList(nonSurgeryObs()));
+
+        when(orderService.getOrderTypeByName("General Order")).thenReturn(orderTypeWithName("General Order"));
+        when(orderService.saveOrder(any(Order.class), eq(null))).thenReturn(new Order());
+        when(orderService.getCareSettingByName("OUTPATIENT")).thenReturn(new CareSetting());
+        when(conceptService.getConceptByName("Select Surgery")).thenReturn(new Concept());
+
+        command.save(bet, encounterWithProvider(), new EncounterTransaction());
+
+        verify(orderService).getOrderTypeByName("General Order");
+        verify(orderService, never()).getOrderTypeByName("Surgery Order");
+        verify(surgicalAppointmentService, never()).getSurgicalAppointmentByUuid(anyString());
+    }
+
+    @Test
+    public void shouldReuseExistingSurgeryOrderAndLinkUnlinkedObs() {
+        BahmniEncounterTransaction bet = new BahmniEncounterTransaction();
+        bet.setObservations(Collections.singletonList(buildSelectSurgeryObs("appt-uuid-123")));
+
+        Encounter encounter = encounterWithProvider();
+        encounter.setOrders(Collections.singleton(existingOrderOfType("Surgery Order")));
+
+        command.save(bet, encounter, new EncounterTransaction());
+
+        verify(orderService, never()).saveOrder(any(Order.class), any());
+        verify(query).executeUpdate();
+    }
+
+    @Test
+    public void shouldReuseExistingGeneralOrderAndLinkUnlinkedObs() {
+        BahmniEncounterTransaction bet = new BahmniEncounterTransaction();
+        bet.setObservations(Collections.singletonList(nonSurgeryObs()));
+
+        Encounter encounter = encounterWithProvider();
+        encounter.setOrders(Collections.singleton(existingOrderOfType("General Order")));
+
+        command.save(bet, encounter, new EncounterTransaction());
+
+        verify(orderService, never()).saveOrder(any(Order.class), any());
+        verify(query).executeUpdate();
+    }
+
+    @Test
+    public void shouldCreateSurgeryOrderEvenWhenGeneralOrderExistsOnEncounter() {
+        BahmniEncounterTransaction bet = new BahmniEncounterTransaction();
+        bet.setObservations(Collections.singletonList(buildSelectSurgeryObs("appt-uuid-999")));
+
+        Encounter encounter = encounterWithProvider();
+        encounter.setOrders(Collections.singleton(existingOrderOfType("General Order")));
+
+        OrderType surgeryType = orderTypeWithName("Surgery Order");
+        when(orderService.getOrderTypeByName("Surgery Order")).thenReturn(surgeryType);
+        when(orderService.saveOrder(any(Order.class), eq(null))).thenReturn(new Order());
+        when(orderService.getCareSettingByName("OUTPATIENT")).thenReturn(new CareSetting());
+        when(conceptService.getConceptByName("Select Surgery")).thenReturn(new Concept());
+
+        SurgicalAppointment appt = new SurgicalAppointment();
+        PowerMockito.when(Context.getService(SurgicalAppointmentService.class)).thenReturn(surgicalAppointmentService);
+        when(surgicalAppointmentService.getSurgicalAppointmentByUuid("appt-uuid-999")).thenReturn(appt);
+
+        command.save(bet, encounter, new EncounterTransaction());
+
+        verify(orderService).saveOrder(any(Order.class), eq(null));
+    }
+
+    @Test
+    public void shouldReturnGracefullyWhenOrderTypeNotConfigured() {
+        BahmniEncounterTransaction bet = new BahmniEncounterTransaction();
+        bet.setObservations(new ArrayList<>());
+
+        when(orderService.getOrderTypeByName(any(String.class))).thenReturn(null);
+
+        command.save(bet, encounterWithProvider(), new EncounterTransaction());
+
+        verify(orderService, never()).saveOrder(any(Order.class), any());
+        verify(query, never()).executeUpdate();
+    }
+
+    @Test
+    public void shouldDetectSelectSurgeryObsNestedInGroupMember() {
+        BahmniEncounterTransaction bet = new BahmniEncounterTransaction();
+
+        BahmniObservation outer = new BahmniObservation();
+        EncounterTransaction.Concept outerConcept = new EncounterTransaction.Concept();
+        outerConcept.setName("Operative Report");
+        outer.setConcept(outerConcept);
+        List<BahmniObservation> groupMembers = new ArrayList<>();
+        groupMembers.add(buildSelectSurgeryObs("nested-appt-uuid"));
+        outer.setGroupMembers(groupMembers);
+        bet.setObservations(Collections.singletonList(outer));
+
+        when(orderService.getOrderTypeByName("Surgery Order")).thenReturn(orderTypeWithName("Surgery Order"));
+        when(orderService.saveOrder(any(Order.class), eq(null))).thenReturn(new Order());
+        when(orderService.getCareSettingByName("OUTPATIENT")).thenReturn(new CareSetting());
+        when(conceptService.getConceptByName("Select Surgery")).thenReturn(new Concept());
+
+        PowerMockito.when(Context.getService(SurgicalAppointmentService.class)).thenReturn(surgicalAppointmentService);
+        when(surgicalAppointmentService.getSurgicalAppointmentByUuid("nested-appt-uuid"))
+                .thenReturn(new SurgicalAppointment());
+
+        command.save(bet, encounterWithProvider(), new EncounterTransaction());
+
+        verify(orderService).getOrderTypeByName("Surgery Order");
+        verify(surgicalAppointmentService).getSurgicalAppointmentByUuid("nested-appt-uuid");
+    }
+
+    // --- helpers ---
+
+    private BahmniObservation buildSelectSurgeryObs(String apptUuid) {
+        BahmniObservation obs = new BahmniObservation();
+        EncounterTransaction.Concept concept = new EncounterTransaction.Concept();
+        concept.setName("Select Surgery");
+        obs.setConcept(concept);
+        obs.setValue(apptUuid);
+        return obs;
+    }
+
+    private BahmniObservation nonSurgeryObs() {
+        BahmniObservation obs = new BahmniObservation();
+        EncounterTransaction.Concept concept = new EncounterTransaction.Concept();
+        concept.setName("Some Other Concept");
+        obs.setConcept(concept);
+        obs.setValue("some-value");
+        return obs;
+    }
+
+    private OrderType orderTypeWithName(String name) {
+        OrderType ot = new OrderType();
+        ot.setName(name);
+        return ot;
+    }
+
+    private Order existingOrderOfType(String typeName) {
+        Order order = new Order();
+        order.setOrderType(orderTypeWithName(typeName));
+        order.setVoided(false);
+        return order;
+    }
+
+    private Encounter encounterWithProvider() {
+        Encounter encounter = new Encounter();
+        Provider provider = new Provider();
+        EncounterProvider ep = new EncounterProvider();
+        ep.setProvider(provider);
+        encounter.setEncounterProviders(Collections.singleton(ep));
+        encounter.setOrders(new HashSet<>());
+        return encounter;
+    }
+}

--- a/bahmni-emr-api/src/test/java/org/openmrs/module/bahmniemrapi/encountertransaction/command/impl/SurgeryOrderPostSaveCommandImplTest.java
+++ b/bahmni-emr-api/src/test/java/org/openmrs/module/bahmniemrapi/encountertransaction/command/impl/SurgeryOrderPostSaveCommandImplTest.java
@@ -9,8 +9,10 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.openmrs.CareSetting;
 import org.openmrs.Concept;
+import org.openmrs.ConceptName;
 import org.openmrs.Encounter;
 import org.openmrs.EncounterProvider;
+import org.openmrs.Obs;
 import org.openmrs.Order;
 import org.openmrs.OrderType;
 import org.openmrs.Provider;
@@ -19,7 +21,6 @@ import org.openmrs.api.OrderService;
 import org.openmrs.api.ProviderService;
 import org.openmrs.api.context.Context;
 import org.openmrs.module.bahmniemrapi.encountertransaction.contract.BahmniEncounterTransaction;
-import org.openmrs.module.bahmniemrapi.encountertransaction.contract.BahmniObservation;
 import org.openmrs.module.emrapi.encounter.domain.EncounterTransaction;
 import org.openmrs.module.operationtheater.api.model.SurgicalAppointment;
 import org.openmrs.module.operationtheater.api.service.SurgicalAppointmentService;
@@ -31,7 +32,6 @@ import org.powermock.modules.junit4.PowerMockRunner;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 
 import static org.mockito.Matchers.any;
@@ -73,7 +73,7 @@ public class SurgeryOrderPostSaveCommandImplTest {
     @Test
     public void shouldCreateSurgeryOrderWhenSelectSurgeryObsPresent() {
         BahmniEncounterTransaction bet = new BahmniEncounterTransaction();
-        bet.setObservations(Collections.singletonList(buildSelectSurgeryObs("appt-uuid-123")));
+        bet.setObservations(new ArrayList<>());
 
         OrderType surgeryOrderType = orderTypeWithName("Surgery Order");
         when(orderService.getOrderTypeByName("Surgery Order")).thenReturn(surgeryOrderType);
@@ -85,7 +85,10 @@ public class SurgeryOrderPostSaveCommandImplTest {
         PowerMockito.when(Context.getService(SurgicalAppointmentService.class)).thenReturn(surgicalAppointmentService);
         when(surgicalAppointmentService.getSurgicalAppointmentByUuid("appt-uuid-123")).thenReturn(appt);
 
-        command.save(bet, encounterWithProvider(), new EncounterTransaction());
+        Encounter encounter = encounterWithProvider();
+        encounter.addObs(selectSurgeryObs("appt-uuid-123"));
+
+        command.save(bet, encounter, new EncounterTransaction());
 
         verify(orderService).getOrderTypeByName("Surgery Order");
         verify(orderService).saveOrder(any(Order.class), eq(null));
@@ -96,7 +99,7 @@ public class SurgeryOrderPostSaveCommandImplTest {
     @Test
     public void shouldCreateGeneralOrderWhenNoSelectSurgeryObs() {
         BahmniEncounterTransaction bet = new BahmniEncounterTransaction();
-        bet.setObservations(Collections.singletonList(nonSurgeryObs()));
+        bet.setObservations(new ArrayList<>());
 
         when(orderService.getOrderTypeByName("General Order")).thenReturn(orderTypeWithName("General Order"));
         when(orderService.saveOrder(any(Order.class), eq(null))).thenReturn(new Order());
@@ -111,12 +114,44 @@ public class SurgeryOrderPostSaveCommandImplTest {
     }
 
     @Test
-    public void shouldReuseExistingSurgeryOrderAndLinkUnlinkedObs() {
+    public void shouldCreateGeneralOrderWhenSelectSurgeryObsAlreadyLinkedToExistingOrder() {
+        // Simulates Form 2 (non-surgery) submitted on same encounter as Form 1 (surgery).
+        // The "Select Surgery" obs from Form 1 already has an order linked — it must be ignored.
         BahmniEncounterTransaction bet = new BahmniEncounterTransaction();
-        bet.setObservations(Collections.singletonList(buildSelectSurgeryObs("appt-uuid-123")));
+        bet.setObservations(new ArrayList<>());
+
+        when(orderService.getOrderTypeByName("General Order")).thenReturn(orderTypeWithName("General Order"));
+        when(orderService.saveOrder(any(Order.class), eq(null))).thenReturn(new Order());
+        when(orderService.getCareSettingByName("OUTPATIENT")).thenReturn(new CareSetting());
+        when(conceptService.getConceptByName("Select Surgery")).thenReturn(new Concept());
 
         Encounter encounter = encounterWithProvider();
-        encounter.setOrders(Collections.singleton(existingOrderOfType("Surgery Order")));
+        // "Select Surgery" obs from Form 1 already has an order — should be ignored
+        Obs alreadyLinkedSelectSurgeryObs = selectSurgeryObs("old-appt-uuid");
+        alreadyLinkedSelectSurgeryObs.setOrder(existingOrderOfType("Surgery Order"));
+        encounter.addObs(alreadyLinkedSelectSurgeryObs);
+
+        command.save(bet, encounter, new EncounterTransaction());
+
+        verify(orderService).getOrderTypeByName("General Order");
+        verify(orderService, never()).getOrderTypeByName("Surgery Order");
+    }
+
+    @Test
+    public void shouldReuseExistingSurgeryOrderWhenSameSurgicalAppointmentSubmitsAgain() {
+        // Same surgical appointment submitting a second operative report — must reuse existing Surgery Order
+        BahmniEncounterTransaction bet = new BahmniEncounterTransaction();
+        bet.setObservations(new ArrayList<>());
+
+        Order existingSurgeryOrder = existingOrderOfType("Surgery Order");
+        SurgicalAppointment appt = new SurgicalAppointment();
+        appt.setOrder(existingSurgeryOrder);
+
+        PowerMockito.when(Context.getService(SurgicalAppointmentService.class)).thenReturn(surgicalAppointmentService);
+        when(surgicalAppointmentService.getSurgicalAppointmentByUuid("appt-uuid-123")).thenReturn(appt);
+
+        Encounter encounter = encounterWithProvider();
+        encounter.addObs(selectSurgeryObs("appt-uuid-123"));
 
         command.save(bet, encounter, new EncounterTransaction());
 
@@ -125,9 +160,40 @@ public class SurgeryOrderPostSaveCommandImplTest {
     }
 
     @Test
+    public void shouldCreateNewSurgeryOrderWhenDifferentSurgicalAppointmentOnSameEncounter() {
+        // Surgery A already has a Surgery Order. Surgery B must get its own new Surgery Order.
+        BahmniEncounterTransaction bet = new BahmniEncounterTransaction();
+        bet.setObservations(new ArrayList<>());
+
+        // Surgery B appointment has no order yet
+        SurgicalAppointment apptB = new SurgicalAppointment();
+
+        PowerMockito.when(Context.getService(SurgicalAppointmentService.class)).thenReturn(surgicalAppointmentService);
+        when(surgicalAppointmentService.getSurgicalAppointmentByUuid("appt-uuid-B")).thenReturn(apptB);
+        when(surgicalAppointmentService.getSurgicalAppointmentByUuid("appt-uuid-B")).thenReturn(apptB);
+
+        when(orderService.getOrderTypeByName("Surgery Order")).thenReturn(orderTypeWithName("Surgery Order"));
+        when(orderService.saveOrder(any(Order.class), eq(null))).thenReturn(new Order());
+        when(orderService.getCareSettingByName("OUTPATIENT")).thenReturn(new CareSetting());
+        when(conceptService.getConceptByName("Select Surgery")).thenReturn(new Concept());
+
+        Encounter encounter = encounterWithProvider();
+        // Surgery A order already on encounter
+        encounter.setOrders(Collections.singleton(existingOrderOfType("Surgery Order")));
+        // New form is for Surgery B
+        encounter.addObs(selectSurgeryObs("appt-uuid-B"));
+
+        command.save(bet, encounter, new EncounterTransaction());
+
+        // Must create a new Surgery Order for Surgery B, not reuse Surgery A's order
+        verify(orderService).saveOrder(any(Order.class), eq(null));
+        verify(surgicalAppointmentService).save(apptB);
+    }
+
+    @Test
     public void shouldReuseExistingGeneralOrderAndLinkUnlinkedObs() {
         BahmniEncounterTransaction bet = new BahmniEncounterTransaction();
-        bet.setObservations(Collections.singletonList(nonSurgeryObs()));
+        bet.setObservations(new ArrayList<>());
 
         Encounter encounter = encounterWithProvider();
         encounter.setOrders(Collections.singleton(existingOrderOfType("General Order")));
@@ -141,9 +207,10 @@ public class SurgeryOrderPostSaveCommandImplTest {
     @Test
     public void shouldCreateSurgeryOrderEvenWhenGeneralOrderExistsOnEncounter() {
         BahmniEncounterTransaction bet = new BahmniEncounterTransaction();
-        bet.setObservations(Collections.singletonList(buildSelectSurgeryObs("appt-uuid-999")));
+        bet.setObservations(new ArrayList<>());
 
         Encounter encounter = encounterWithProvider();
+        encounter.addObs(selectSurgeryObs("appt-uuid-999"));
         encounter.setOrders(Collections.singleton(existingOrderOfType("General Order")));
 
         OrderType surgeryType = orderTypeWithName("Surgery Order");
@@ -175,17 +242,9 @@ public class SurgeryOrderPostSaveCommandImplTest {
     }
 
     @Test
-    public void shouldDetectSelectSurgeryObsNestedInGroupMember() {
+    public void shouldDetectSelectSurgeryObsOnEncounter() {
         BahmniEncounterTransaction bet = new BahmniEncounterTransaction();
-
-        BahmniObservation outer = new BahmniObservation();
-        EncounterTransaction.Concept outerConcept = new EncounterTransaction.Concept();
-        outerConcept.setName("Operative Report");
-        outer.setConcept(outerConcept);
-        List<BahmniObservation> groupMembers = new ArrayList<>();
-        groupMembers.add(buildSelectSurgeryObs("nested-appt-uuid"));
-        outer.setGroupMembers(groupMembers);
-        bet.setObservations(Collections.singletonList(outer));
+        bet.setObservations(new ArrayList<>());
 
         when(orderService.getOrderTypeByName("Surgery Order")).thenReturn(orderTypeWithName("Surgery Order"));
         when(orderService.saveOrder(any(Order.class), eq(null))).thenReturn(new Order());
@@ -196,29 +255,29 @@ public class SurgeryOrderPostSaveCommandImplTest {
         when(surgicalAppointmentService.getSurgicalAppointmentByUuid("nested-appt-uuid"))
                 .thenReturn(new SurgicalAppointment());
 
-        command.save(bet, encounterWithProvider(), new EncounterTransaction());
+        Encounter encounter = encounterWithProvider();
+        encounter.addObs(selectSurgeryObs("nested-appt-uuid"));
+
+        command.save(bet, encounter, new EncounterTransaction());
 
         verify(orderService).getOrderTypeByName("Surgery Order");
-        verify(surgicalAppointmentService).getSurgicalAppointmentByUuid("nested-appt-uuid");
+        // Called twice: once to check for existing order, once to link the appointment to the new order
+        verify(surgicalAppointmentService, org.mockito.Mockito.times(2)).getSurgicalAppointmentByUuid("nested-appt-uuid");
     }
 
     // --- helpers ---
 
-    private BahmniObservation buildSelectSurgeryObs(String apptUuid) {
-        BahmniObservation obs = new BahmniObservation();
-        EncounterTransaction.Concept concept = new EncounterTransaction.Concept();
-        concept.setName("Select Surgery");
-        obs.setConcept(concept);
-        obs.setValue(apptUuid);
-        return obs;
-    }
+    private Obs selectSurgeryObs(String apptUuid) {
+        ConceptName conceptName = new ConceptName();
+        conceptName.setName("Select Surgery");
 
-    private BahmniObservation nonSurgeryObs() {
-        BahmniObservation obs = new BahmniObservation();
-        EncounterTransaction.Concept concept = new EncounterTransaction.Concept();
-        concept.setName("Some Other Concept");
+        Concept concept = PowerMockito.mock(Concept.class);
+        when(concept.getName()).thenReturn(conceptName);
+
+        Obs obs = new Obs();
         obs.setConcept(concept);
-        obs.setValue("some-value");
+        obs.setValueComplex(apptUuid);
+        obs.setVoided(false);
         return obs;
     }
 

--- a/bahmnicore-api/src/main/java/org/bahmni/module/bahmnicore/obs/handler/SurgicalBlockObsHandler.java
+++ b/bahmnicore-api/src/main/java/org/bahmni/module/bahmnicore/obs/handler/SurgicalBlockObsHandler.java
@@ -1,0 +1,46 @@
+package org.bahmni.module.bahmnicore.obs.handler;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.openmrs.Obs;
+import org.openmrs.api.APIException;
+import org.openmrs.obs.ComplexData;
+import org.openmrs.obs.ComplexObsHandler;
+import org.openmrs.obs.handler.AbstractHandler;
+import org.springframework.stereotype.Component;
+
+@Component
+public class SurgicalBlockObsHandler extends AbstractHandler implements ComplexObsHandler {
+
+    public static final Log log = LogFactory.getLog(SurgicalBlockObsHandler.class);
+
+    private static final String[] SUPPORTED_VIEWS = new String[] {
+            ComplexObsHandler.RAW_VIEW, ComplexObsHandler.URI_VIEW,
+            ComplexObsHandler.HTML_VIEW, ComplexObsHandler.TEXT_VIEW };
+
+    @Override
+    public Obs saveObs(Obs obs) throws APIException {
+        obs.setComplexData(null);
+        obs.setValueComplex(obs.getValueComplex());
+        return obs;
+    }
+
+    @Override
+    public Obs getObs(Obs obs, String view) {
+        try {
+            String surgicalAppointmentUuid = obs.getValueComplex();
+            if (surgicalAppointmentUuid != null && !surgicalAppointmentUuid.isEmpty()) {
+                obs.setComplexData(new ComplexData(surgicalAppointmentUuid, surgicalAppointmentUuid));
+            }
+        } catch (Exception e) {
+            log.error("Error retrieving surgical block obs data for obs [concept:"
+                    + obs.getConcept().getId() + "].", e);
+        }
+        return obs;
+    }
+
+    @Override
+    public String[] getSupportedViews() {
+        return SUPPORTED_VIEWS;
+    }
+}

--- a/bahmnicore-api/src/main/java/org/bahmni/module/bahmnicore/obs/handler/SurgicalBlockObsHandler.java
+++ b/bahmnicore-api/src/main/java/org/bahmni/module/bahmnicore/obs/handler/SurgicalBlockObsHandler.java
@@ -14,7 +14,7 @@ public class SurgicalBlockObsHandler extends AbstractHandler implements ComplexO
 
     public static final Log log = LogFactory.getLog(SurgicalBlockObsHandler.class);
 
-    private static final String[] SUPPORTED_VIEWS = new String[] {
+    private static final String[] supportedViews = new String[] {
             ComplexObsHandler.RAW_VIEW, ComplexObsHandler.URI_VIEW,
             ComplexObsHandler.HTML_VIEW, ComplexObsHandler.TEXT_VIEW };
 
@@ -41,6 +41,6 @@ public class SurgicalBlockObsHandler extends AbstractHandler implements ComplexO
 
     @Override
     public String[] getSupportedViews() {
-        return SUPPORTED_VIEWS;
+        return supportedViews;
     }
 }

--- a/bahmnicore-api/src/main/resources/moduleApplicationContext.xml
+++ b/bahmnicore-api/src/main/resources/moduleApplicationContext.xml
@@ -51,6 +51,10 @@
                     <key><value>ProviderObsHandler</value></key>
                     <bean class="org.bahmni.module.bahmnicore.obs.handler.ProviderObsHandler"/>
                 </entry>
+                <entry>
+                    <key><value>SurgicalBlockObsHandler</value></key>
+                    <bean class="org.bahmni.module.bahmnicore.obs.handler.SurgicalBlockObsHandler"/>
+                </entry>
             </map>
         </property>
     </bean>
@@ -133,6 +137,7 @@
             <list>
                 <ref bean="bahmniObservationSaveCommandImpl"/>
                 <ref bean="episodeEncounterCreateCommand"/>
+                <ref bean="surgeryOrderPostSaveCommandImpl"/>
             </list>
         </constructor-arg>
         <constructor-arg ref="bahmniEncounterTransactionMapper" />

--- a/bahmnicore-omod/src/main/resources/config.xml
+++ b/bahmnicore-omod/src/main/resources/config.xml
@@ -34,6 +34,7 @@
         <require_module>org.openmrs.module.auditlog</require_module>
         <require_module>org.bahmni.module.bahmnicommons</require_module>
         <require_module>org.bahmni.module.communication</require_module>
+        <require_module>org.openmrs.module.operationtheater</require_module>
     </require_modules>
     <!-- Extensions -->
 

--- a/bahmnicore-omod/src/main/resources/liquibase.xml
+++ b/bahmnicore-omod/src/main/resources/liquibase.xml
@@ -4788,6 +4788,21 @@
         </sql>
     </changeSet>
 
+    <changeSet id="add-surgery-selection-concept-gp" author="vivek">
+        <preConditions onFail="MARK_RAN">
+            <sqlCheck expectedResult="0">
+                SELECT COUNT(*) FROM global_property
+                WHERE property = 'bahmnicore.order.surgerySelectionConcept'
+            </sqlCheck>
+        </preConditions>
+        <insert tableName="global_property">
+            <column name="property" value="bahmnicore.order.surgerySelectionConcept"/>
+            <column name="property_value" value="Select Surgery"/>
+            <column name="description" value="Concept name used to identify surgery selection obs and link orders. Change this if your deployment uses a different concept name."/>
+            <column name="uuid" value="a9f3c2e1-b4d5-4e6f-8a7b-c1d2e3f4a5b6"/>
+        </insert>
+    </changeSet>
+
     <changeSet id="add-surgery-order-type" author="vivek">
         <preConditions onFail="MARK_RAN">
             <sqlCheck expectedResult="0">SELECT COUNT(*) FROM order_type WHERE name = 'Surgery Order'</sqlCheck>

--- a/bahmnicore-omod/src/main/resources/liquibase.xml
+++ b/bahmnicore-omod/src/main/resources/liquibase.xml
@@ -4788,21 +4788,6 @@
         </sql>
     </changeSet>
 
-    <changeSet id="add-surgery-selection-concept-gp" author="vivek">
-        <preConditions onFail="MARK_RAN">
-            <sqlCheck expectedResult="0">
-                SELECT COUNT(*) FROM global_property
-                WHERE property = 'bahmnicore.order.surgerySelectionConcept'
-            </sqlCheck>
-        </preConditions>
-        <insert tableName="global_property">
-            <column name="property" value="bahmnicore.order.surgerySelectionConcept"/>
-            <column name="property_value" value="Select Surgery"/>
-            <column name="description" value="Concept name used to identify surgery selection obs and link orders. Change this if your deployment uses a different concept name."/>
-            <column name="uuid" value="a9f3c2e1-b4d5-4e6f-8a7b-c1d2e3f4a5b6"/>
-        </insert>
-    </changeSet>
-
     <changeSet id="add-surgery-order-type" author="vivek">
         <preConditions onFail="MARK_RAN">
             <sqlCheck expectedResult="0">SELECT COUNT(*) FROM order_type WHERE name = 'Surgery Order'</sqlCheck>

--- a/bahmnicore-omod/src/main/resources/liquibase.xml
+++ b/bahmnicore-omod/src/main/resources/liquibase.xml
@@ -4788,6 +4788,33 @@
         </sql>
     </changeSet>
 
+    <changeSet id="cure-surgery-order-type-1" author="vivek">
+        <preConditions onFail="MARK_RAN">
+            <sqlCheck expectedResult="0">SELECT COUNT(*) FROM order_type WHERE name = 'Surgery Order'</sqlCheck>
+        </preConditions>
+        <insert tableName="order_type">
+            <column name="name" value="Surgery Order"/>
+            <column name="description" value="Order created when an operative report is linked to a surgical appointment"/>
+            <column name="java_class_name" value="org.openmrs.Order"/>
+            <column name="date_created" valueDate="now()"/>
+            <column name="creator" value="1"/>
+            <column name="uuid" valueComputed="UUID()"/>
+        </insert>
+    </changeSet>
+    <changeSet id="cure-general-order-type-1" author="vivek">
+        <preConditions onFail="MARK_RAN">
+            <sqlCheck expectedResult="0">SELECT COUNT(*) FROM order_type WHERE name = 'General Order'</sqlCheck>
+        </preConditions>
+        <insert tableName="order_type">
+            <column name="name" value="General Order"/>
+            <column name="description" value="Order created for operative forms without a selected surgical appointment"/>
+            <column name="java_class_name" value="org.openmrs.Order"/>
+            <column name="date_created" valueDate="now()"/>
+            <column name="creator" value="1"/>
+            <column name="uuid" valueComputed="UUID()"/>
+        </insert>
+    </changeSet>
+
     <changeSet id="bahmni-core-20260518-116474-remove-delete-form-draft-privilege" author="Bahmni">
         <preConditions onFail="MARK_RAN">
             <sqlCheck expectedResult="1">

--- a/bahmnicore-omod/src/main/resources/liquibase.xml
+++ b/bahmnicore-omod/src/main/resources/liquibase.xml
@@ -4788,7 +4788,7 @@
         </sql>
     </changeSet>
 
-    <changeSet id="cure-surgery-order-type-1" author="vivek">
+    <changeSet id="add-surgery-order-type" author="vivek">
         <preConditions onFail="MARK_RAN">
             <sqlCheck expectedResult="0">SELECT COUNT(*) FROM order_type WHERE name = 'Surgery Order'</sqlCheck>
         </preConditions>
@@ -4798,10 +4798,10 @@
             <column name="java_class_name" value="org.openmrs.Order"/>
             <column name="date_created" valueDate="now()"/>
             <column name="creator" value="1"/>
-            <column name="uuid" valueComputed="UUID()"/>
+            <column name="uuid" value="c1e3d8a2-4f7b-4a9e-b5c6-d2f8e3a1b4c7"/>
         </insert>
     </changeSet>
-    <changeSet id="cure-general-order-type-1" author="vivek">
+    <changeSet id="add-general-order-type" author="vivek">
         <preConditions onFail="MARK_RAN">
             <sqlCheck expectedResult="0">SELECT COUNT(*) FROM order_type WHERE name = 'General Order'</sqlCheck>
         </preConditions>
@@ -4811,7 +4811,7 @@
             <column name="java_class_name" value="org.openmrs.Order"/>
             <column name="date_created" valueDate="now()"/>
             <column name="creator" value="1"/>
-            <column name="uuid" valueComputed="UUID()"/>
+            <column name="uuid" value="d4e5f6a7-b8c9-4d2e-a3f1-e7b6c5d4a3f2"/>
         </insert>
     </changeSet>
 

--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,7 @@
         <auditLogVersion>1.3.0</auditLogVersion>
         <bacteriology.version>1.3.0</bacteriology.version>
         <rulesEngineVersion>1.1.0-SNAPSHOT</rulesEngineVersion>
+        <operationtheater.version>1.9.0-SNAPSHOT</operationtheater.version>
         <bahmniJavaUtilsVersion>1.0.0</bahmniJavaUtilsVersion>
         <javaxServletVersion>4.0.1</javaxServletVersion>
         <log4jVersion>2.17.1</log4jVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -812,6 +812,11 @@
             <name>GitHub Packages</name>
             <url>https://maven.pkg.github.com/cureinternational/openmrs-module-rulesengine</url>
         </repository>
+        <repository>
+            <id>github-operationtheater</id>
+            <name>GitHub Packages - Operation Theater</name>
+            <url>https://maven.pkg.github.com/cureinternational/openmrs-module-operationtheater</url>
+        </repository>
     <repository>
           <id>repo.mybahmni.org-release</id>
           <name>bahmni-artifactory-release</name>


### PR DESCRIPTION
## Summary

- **`SurgeryOrderPostSaveCommandImpl`** — post-save command creating Surgery/General Order per form submission. Order lookup keyed on `surgicalAppointmentUuid` ensuring different surgical appointments in the same encounter each get their own Surgery Order.
- **`SurgeryObsOrderLinkDao`** — new DAO (`assignOrderToUnlinkedObs`) in `bahmni-emr-api` layer extracts HQL bulk update from command.
- **`SurgicalBlockObsHandler`** — `ComplexObsHandler` for the surgery selection concept.
- **Liquibase** — seeds `Surgery Order` and `General Order` order types.
- **`pom.xml`** — `operationtheater-api` version managed via `${operationtheater.version}` property in parent pom.

## Feature Toggle via Global Property

```
bahmnicore.order.surgerySelectionConceptUuid = <UUID of Select Surgery concept>
```

- **GP configured** → concept found → Surgery/General Order created for all form submissions ✅
- **GP not configured** → concept null → order creation skipped gracefully, no errors ✅

This makes the feature **incrementally deployable** — ship the code, configure the GP when ready. No flag days, no breaking changes.

The GP value (concept UUID) is seeded via `cure-bahmni-emr` master data — not owned by bahmni-core since the concept is deployment-specific.

## Behaviour

| Scenario | Result |
|---|---|
| Surgery form (Select Surgery filled) | `Surgery Order` created; obs + `surgical_appointment.order_id` linked |
| Non-surgery form (same encounter) | `General Order` created; obs linked separately |
| Same surgical appointment submits again | Existing Surgery Order reused (keyed on appointment UUID) |
| Different surgical appointment, same encounter | New Surgery Order — does NOT reuse the first surgery's order |
| Form re-edit | No duplicate order; only newly added obs linked (`WHERE order IS NULL`) |
| GP not configured | No order created; encounter save unaffected |

## Review Comments Addressed

| Comment | Status |
|---|---|
| `getConceptByName()` null guard | ✅ Fixed |
| `careSetting` null guard | ✅ Fixed |
| `ProviderService` unused | ✅ Fixed — removed |
| `SessionFactory` → DAO | ✅ Fixed — `SurgeryObsOrderLinkDao.assignOrderToUnlinkedObs()` |
| `operationtheater-api` version hardcoded | ✅ Fixed — `${operationtheater.version}` |
| `UUID()` MySQL-specific in Liquibase | ✅ Fixed — fixed UUID literals |
| `SUPPORTED_VIEWS` naming | ✅ Fixed — renamed to `supportedViews` |
| Concept hardcoded | ✅ Fixed — configurable via `bahmnicore.order.surgerySelectionConceptUuid` GP |

## Open Items (Pending Tech Lead Discussion)

| Item | Notes |
|---|---|
| `require_module operationtheater` in `config.xml` | Cross-module integration decision — see `HIVE-113267_cross_module_integration.md` |
| Concept for General Order | "Select Surgery" used as DB placeholder for both order types — acceptable since no concept class constraints. Option B (dedicated concept) deferred. |

## Follow-up PRs

- `openmrs-module-operationtheater` [#1](https://github.com/cureinternational/openmrs-module-operationtheater/pull/1)
- `openmrs-module-fhir2Extension` [#4](https://github.com/cureinternational/openmrs-module-fhir2Extension/pull/4)
- `openmrs-module-ipd-frontend` [#77](https://github.com/cureinternational/openmrs-module-ipd-frontend/pull/77)
- `openmrs-module-bahmniapps` [#174](https://github.com/cureinternational/openmrs-module-bahmniapps/pull/174)

🤖 Generated with [Claude Code](https://claude.com/claude-code)