### PR TITLE
Populate visit type in encounter event to be consumed by openelis

### DIFF
--- a/bahmni-emr-api/src/main/java/org/openmrs/module/bahmniemrapi/encountertransaction/mapper/BahmniEncounterTransactionMapper.java
+++ b/bahmni-emr-api/src/main/java/org/openmrs/module/bahmniemrapi/encountertransaction/mapper/BahmniEncounterTransactionMapper.java
@@ -3,8 +3,10 @@ package org.openmrs.module.bahmniemrapi.encountertransaction.mapper;
 import org.openmrs.EncounterType;
 import org.openmrs.Patient;
 import org.openmrs.PatientIdentifier;
+import org.openmrs.VisitType;
 import org.openmrs.api.EncounterService;
 import org.openmrs.api.PatientService;
+import org.openmrs.api.VisitService;
 import org.openmrs.module.bahmniemrapi.accessionnote.mapper.AccessionNotesMapper;
 import org.openmrs.module.bahmniemrapi.diagnosis.contract.BahmniDiagnosisRequest;
 import org.openmrs.module.bahmniemrapi.diagnosis.helper.BahmniDiagnosisMetadata;
@@ -12,6 +14,7 @@ import org.openmrs.module.bahmniemrapi.encountertransaction.contract.BahmniEncou
 import org.openmrs.module.bahmniemrapi.encountertransaction.contract.BahmniObservation;
 import org.openmrs.module.bahmniemrapi.encountertransaction.mapper.parameters.AdditionalBahmniObservationFields;
 import org.openmrs.module.emrapi.encounter.domain.EncounterTransaction;
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
@@ -24,6 +27,7 @@ public class BahmniEncounterTransactionMapper {
     private ObsRelationshipMapper obsRelationshipMapper;
     private PatientService patientService;
     private EncounterService encounterService;
+    private VisitService visitService;
     private ETObsToBahmniObsMapper fromETObsToBahmniObs;
 
     @Autowired
@@ -32,12 +36,14 @@ public class BahmniEncounterTransactionMapper {
                                             ObsRelationshipMapper obsRelationshipMapper,
                                             PatientService patientService,
                                             EncounterService encounterService,
+                                            VisitService visitService,
                                             ETObsToBahmniObsMapper fromETObsToBahmniObs) {
         this.accessionNotesMapper = accessionNotesMapper;
         this.bahmniDiagnosisMetadata = bahmniDiagnosisMetadata;
         this.obsRelationshipMapper = obsRelationshipMapper;
         this.patientService = patientService;
         this.encounterService = encounterService;
+        this.visitService = visitService;
         this.fromETObsToBahmniObs = fromETObsToBahmniObs;
     }
 
@@ -52,6 +58,7 @@ public class BahmniEncounterTransactionMapper {
         bahmniEncounterTransaction.setObservations(obsRelationshipMapper.map(bahmniObservations, encounterTransaction.getEncounterUuid()));
         addPatientIdentifier(bahmniEncounterTransaction, encounterTransaction);
         addEncounterType(encounterTransaction, bahmniEncounterTransaction);
+        addVisitType(encounterTransaction, bahmniEncounterTransaction);
         return bahmniEncounterTransaction;
     }
 
@@ -59,6 +66,15 @@ public class BahmniEncounterTransactionMapper {
         EncounterType encounterType = encounterService.getEncounterTypeByUuid(encounterTransaction.getEncounterTypeUuid());
         if (encounterType != null) {
             bahmniEncounterTransaction.setEncounterType(encounterType.getName());
+        }
+    }
+
+    private void addVisitType(EncounterTransaction encounterTransaction, BahmniEncounterTransaction bahmniEncounterTransaction) {
+        if (!StringUtils.isBlank(encounterTransaction.getVisitTypeUuid())) {
+            VisitType visitType = visitService.getVisitTypeByUuid(encounterTransaction.getVisitTypeUuid());
+            if (visitType != null) {
+                bahmniEncounterTransaction.setVisitType(visitType.getName());
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- Populate visit type in encounter event so OpenElis can consume it downstream.

## Test plan
- [ ] Verify encounter event payload includes visit type
- [ ] Verify OpenElis consumes new field correctly