### PR TITLE
Fix compilation error: remove invalid BeanPostProcessor overrides

### DIFF
--- a/bahmni-emr-api/src/main/java/org/openmrs/module/bahmniemrapi/encountertransaction/command/impl/SurgeryObsOrderLinkPreSaveCommandImpl.java
+++ b/bahmni-emr-api/src/main/java/org/openmrs/module/bahmniemrapi/encountertransaction/command/impl/SurgeryObsOrderLinkPreSaveCommandImpl.java
@@ -5,7 +5,6 @@ import org.openmrs.api.AdministrationService;
 import org.openmrs.module.bahmniemrapi.encountertransaction.command.EncounterDataPreSaveCommand;
 import org.openmrs.module.bahmniemrapi.encountertransaction.contract.BahmniEncounterTransaction;
 import org.openmrs.module.bahmniemrapi.encountertransaction.contract.BahmniObservation;
-import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
@@ -87,13 +86,4 @@ public class SurgeryObsOrderLinkPreSaveCommandImpl implements EncounterDataPreSa
         }
     }
 
-    @Override
-    public Object postProcessBeforeInitialization(Object bean, String beanName) throws BeansException {
-        return bean;
-    }
-
-    @Override
-    public Object postProcessAfterInitialization(Object bean, String beanName) throws BeansException {
-        return bean;
-    }
 }


### PR DESCRIPTION
## Summary
- `SurgeryObsOrderLinkPreSaveCommandImpl` implements `EncounterDataPreSaveCommand`, which does not extend Spring's `BeanPostProcessor`
- The `@Override` annotations on `postProcessBeforeInitialization` and `postProcessAfterInitialization` were invalid, causing a compilation failure in CI
- Removed both methods and the unused `BeansException` import

## Test plan
- [ ] CI build passes on this branch (`bahmni-emr-api` compiles cleanly)
- [ ] No functional change — the removed methods were no-ops and were never invoked via this class

🤖 Generated with [Claude Code](https://claude.com/claude-code)